### PR TITLE
Identify keypads from the BLE advertisement, drop cloud SKU matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ knows it isn't talking to a real lock.
 
 ## Supported keypads
 
-The pairing wizard auto-detects the keypad family from the SwitchBot cloud and
-adapts the BLE protocol accordingly.
+The pairing wizard identifies the keypad model **from its BLE advertisement** —
+the same way the official [pySwitchbot](https://github.com/sblibs/pySwitchbot)
+library does — and adapts the pairing protocol accordingly. Detection does not
+depend on the cloud `device_type`/SKU string at all, so a keypad is found and
+paired even if its SKU is one SwitchBot hasn't shipped before.
 
 | Model | Protocol family | Status |
 |---|---|---|
@@ -37,6 +40,10 @@ adapts the BLE protocol accordingly.
 | SwitchBot Keypad Vision | Vision | ✅ **Tested** |
 | SwitchBot Keypad | Original | Supported — same protocol as Touch |
 | SwitchBot Keypad Vision Pro | Vision | Supported — same protocol as Vision |
+
+> Because the keypad is recognised from its live advertisement, keep it within
+> ~2 m and powered while you run the wizard — out-of-range devices won't be
+> listed.
 
 ## Quick start
 

--- a/components/switchbot_keypad_bridge/cloud_client.cpp
+++ b/components/switchbot_keypad_bridge/cloud_client.cpp
@@ -20,43 +20,17 @@ namespace {
 
 const char *const TAG = "switchbot_keypad_bridge.cloud";
 
-// The OAuth-style clientId the official SwitchBot app uses. Mirrored
-// from tools/pair_keypad.py.
+// The OAuth-style clientId the official SwitchBot app uses.
 constexpr const char *CLIENT_ID = "5nnwmhmsa9xxskm14hd85lm9bm";
 
 constexpr const char *ACCOUNT_BASE = "https://account.api.switchbot.net";
 
-// SKU → (friendly name, protocol family). SwitchBot serves the same
-// keypad under two different device_type schemes depending on app
-// version and model generation: the legacy "WoKeypad*" SKUs (typical
-// for Original/Touch) and the new numeric "W1115000"-style codes
-// (typical for Vision/Vision Pro). We accept both.
-//
-// The mapping mirrors `DEVICE_TYPE_TO_PRESET` in tools/pair_keypad.py.
-// W1115001 is a best-guess for Vision Pro — confirmed cloud SKUs:
-//   W1115000 → Keypad Vision (verified from the user's account)
-struct KeypadSku {
-  const char *sku;
-  const char *display_name;
-  CloudClient::KeypadFamily family;
-};
-constexpr KeypadSku KEYPAD_SKUS[] = {
-    // Legacy / friendly SKUs (still served for older keypads)
-    {"WoKeypad",          "Keypad",            CloudClient::KeypadFamily::ORIGINAL},
-    {"WoKeypadTouch",     "Keypad Touch",      CloudClient::KeypadFamily::ORIGINAL},
-    {"WoKeypadVision",    "Keypad Vision",     CloudClient::KeypadFamily::VISION},
-    {"WoKeypadVisionPro", "Keypad Vision Pro", CloudClient::KeypadFamily::VISION},
-    // Numeric SKUs (newer cloud responses)
-    {"W1115000",          "Keypad Vision",     CloudClient::KeypadFamily::VISION},
-    {"W1115001",          "Keypad Vision Pro", CloudClient::KeypadFamily::VISION},
-};
-
-const KeypadSku *sku_lookup(const std::string &sku) {
-  for (auto &k : KEYPAD_SKUS) {
-    if (sku == k.sku) return &k;
-  }
-  return nullptr;
-}
+// NOTE: keypads are no longer identified by their cloud SKU. The cloud is used
+// only to enumerate the account's devices (MAC + name) and to fetch each
+// keypad's communication key. Whether a device *is* a keypad — and which
+// protocol family it speaks — is decided solely from its BLE advertisement, the
+// way the official pySwitchbot library does it (see keypad_advert.h). This keeps
+// us from chasing SwitchBot's ever-growing list of device_type codes.
 
 // Convert "B0E9FE612E75" → "B0:E9:FE:61:2E:75". Idempotent on already-
 // pretty input. Defensive on odd-length strings (returns input as-is).
@@ -279,7 +253,7 @@ bool CloudClient::login(const std::string &email, const std::string &password,
   }
 
   // Step 2: userinfo -> region. Failure here is non-fatal: we default
-  // to "us" and continue, matching pair_keypad.py's behaviour.
+  // to "us" and continue.
   this->region_ = "us";
   {
     std::string url = std::string(ACCOUNT_BASE) + "/account/api/v1/user/userinfo";
@@ -343,16 +317,12 @@ bool CloudClient::list_keypads(std::vector<AccountKeypad> &out_keypads,
     return false;
   }
 
+  // Return every account device that has a MAC. We don't classify here — the
+  // pairing UI decides which of these are keypads purely from each device's
+  // live BLE advertisement (see keypad_advert.h).
   std::vector<AccountKeypad> picked;
   cJSON *item = nullptr;
   cJSON_ArrayForEach(item, items) {
-    cJSON *detail = cJSON_GetObjectItemCaseSensitive(item, "device_detail");
-    if (!cJSON_IsObject(detail)) continue;
-    cJSON *dt = cJSON_GetObjectItemCaseSensitive(detail, "device_type");
-    if (!cJSON_IsString(dt) || dt->valuestring == nullptr) continue;
-    const KeypadSku *sku = sku_lookup(dt->valuestring);
-    if (sku == nullptr) continue;
-
     cJSON *mac = cJSON_GetObjectItemCaseSensitive(item, "device_mac");
     if (!cJSON_IsString(mac) || mac->valuestring == nullptr) continue;
     cJSON *name = cJSON_GetObjectItemCaseSensitive(item, "device_name");
@@ -361,18 +331,15 @@ bool CloudClient::list_keypads(std::vector<AccountKeypad> &out_keypads,
     kp.mac          = compact_mac(mac->valuestring);
     kp.mac_pretty   = pretty_mac(kp.mac);
     kp.name         = (cJSON_IsString(name) && name->valuestring) ? name->valuestring
-                                                                   : sku->display_name;
-    kp.device_type  = dt->valuestring;
-    kp.display_name = sku->display_name;
-    kp.family       = sku->family;
+                                                                   : kp.mac_pretty;
     picked.push_back(std::move(kp));
   }
   cJSON_Delete(root);
 
+  ESP_LOGI(TAG, "Account has %u device(s)", static_cast<unsigned>(picked.size()));
+
   this->keypads_cache_ = picked;
   out_keypads = std::move(picked);
-  ESP_LOGI(TAG, "Found %u keypads in account",
-           static_cast<unsigned>(out_keypads.size()));
   return true;
 }
 

--- a/components/switchbot_keypad_bridge/cloud_client.h
+++ b/components/switchbot_keypad_bridge/cloud_client.h
@@ -2,7 +2,7 @@
 
 // SwitchBot cloud client.
 //
-// Mirrors the four HTTPS calls `tools/pair_keypad.py` makes:
+// Makes four HTTPS calls:
 //
 //   POST  account.api.switchbot.net /account/api/v1/user/login
 //   POST  account.api.switchbot.net /account/api/v1/user/userinfo
@@ -12,7 +12,7 @@
 // The four endpoints together give us:
 //   - an account-wide bearer token
 //   - the user's home region ("us" / "eu" / ...)
-//   - the device list, filtered to keypads
+//   - the account device list (keypad detection happens later, over BLE)
 //   - the keypad's current `communicationKey` (the cloud-issued key the
 //     keypad uses to talk to its currently paired lock)
 //
@@ -28,19 +28,22 @@ namespace switchbot_keypad_bridge {
 
 class CloudClient {
  public:
-  // Pairing-protocol dialect. The SwitchBot Keypad firmware ships in
-  // two families with slightly different BLE handshakes; pair_keypad.py
-  // calls them "original" and "vision".
+  // Pairing-protocol dialect. The SwitchBot Keypad firmware ships in two
+  // families with slightly different BLE handshakes ("original" and "vision").
+  // Which family a keypad speaks is identified from its BLE advertisement
+  // (see keypad_advert.h), not from any cloud field.
   enum class KeypadFamily { ORIGINAL, VISION };
 
-  // Plain-data view of one keypad as returned by /wonder/device/v3/getdevice.
+  // Plain-data view of one account device as returned by
+  // /wonder/device/v3/getdevice. `list_keypads` returns every account device
+  // that carries a MAC. Whether a device is a keypad — and which family it
+  // speaks — is decided by the pairing UI / pairer from its live BLE
+  // advertisement (keypad_advert.h); the cloud only supplies identity (MAC,
+  // name) and, later, the communication key.
   struct AccountKeypad {
     std::string mac;          // hex, no separators: "B0E9FE612E75"
     std::string mac_pretty;   // "B0:E9:FE:61:2E:75"
     std::string name;         // user-set, e.g. "Keypad Vision 75"
-    std::string device_type;  // raw SKU as returned by the cloud
-    std::string display_name; // friendly model, e.g. "Keypad Vision"
-    KeypadFamily family{KeypadFamily::ORIGINAL};
   };
 
   // Authenticate against the SwitchBot account API. Captures the bearer
@@ -49,8 +52,10 @@ class CloudClient {
   bool login(const std::string &email, const std::string &password,
              std::string &error_out);
 
-  // Returns the list of keypads in the user's SwitchBot account.
-  // Successive calls are cached — pass `force_refresh = true` to bypass.
+  // Returns the user's SwitchBot account devices that carry a MAC (keypad
+  // candidates). The caller decides which are really keypads by checking each
+  // one's live BLE advertisement (keypad_advert.h). Successive calls are
+  // cached — pass `force_refresh = true` to bypass.
   bool list_keypads(std::vector<AccountKeypad> &out_keypads,
                     std::string &error_out, bool force_refresh = false);
 

--- a/components/switchbot_keypad_bridge/keypad_advert.cpp
+++ b/components/switchbot_keypad_bridge/keypad_advert.cpp
@@ -1,0 +1,67 @@
+#include "keypad_advert.h"
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+namespace {
+
+// pySwitchbot SUPPORTED_TYPES keypad signatures (SwitchBot service-data,
+// advertised under UUID 0xFD3D — with 0x0D00 as a legacy fallback):
+//
+//   first byte 'y'  (0x79, low 7 bits) ........... Keypad / Keypad Touch → ORIGINAL
+//   4-byte suffix  ?? 11 03 78  (?? = enc bit) .... Keypad Vision         → VISION
+//   4-byte suffix  ?? 11 51 98 ................... Keypad Vision Pro      → VISION
+//
+// The first byte is matched after masking the high (encryption) bit; the
+// Vision variants are matched as a trailing 4-byte window. This mirrors
+// pySwitchbot's `_find_model_from_service_data` (first byte) and
+// `_find_model_from_service_data_suffix` (which tries both the [-4:] and the
+// [-5:-1] window).
+constexpr uint8_t KEYPAD_TYPE_BYTE = 0x79;  // 'y'
+
+// True when a 4-byte window equals `?? b1 b2 b3`, accepting 0x00 or 0x01 as the
+// leading encryption bit (both forms appear in pySwitchbot's table).
+bool suffix_is(const uint8_t *w, uint8_t b1, uint8_t b2, uint8_t b3) {
+  return (w[0] == 0x00 || w[0] == 0x01) && w[1] == b1 && w[2] == b2 &&
+         w[3] == b3;
+}
+
+}  // namespace
+
+KeypadIdent identify_keypad(const uint8_t *svc_data, size_t len) {
+  KeypadIdent id;
+  if (svc_data == nullptr || len == 0) return id;
+
+  // 1. First-byte match (low 7 bits) — Keypad / Keypad Touch (Original family).
+  if ((svc_data[0] & 0x7F) == KEYPAD_TYPE_BYTE) {
+    id.is_keypad = true;
+    id.family = CloudClient::KeypadFamily::ORIGINAL;
+    id.display_name = "Keypad";
+    return id;
+  }
+
+  // 2. Trailing 4-byte window — Vision / Vision Pro (Vision family). Try both
+  //    the last-4 and the next-to-last-4 windows, as pySwitchbot does.
+  if (len > 5) {
+    const uint8_t *windows[] = {svc_data + (len - 4), svc_data + (len - 5)};
+    for (const uint8_t *w : windows) {
+      if (suffix_is(w, 0x11, 0x03, 0x78)) {
+        id.is_keypad = true;
+        id.family = CloudClient::KeypadFamily::VISION;
+        id.display_name = "Keypad Vision";
+        return id;
+      }
+      if (suffix_is(w, 0x11, 0x51, 0x98)) {
+        id.is_keypad = true;
+        id.family = CloudClient::KeypadFamily::VISION;
+        id.display_name = "Keypad Vision Pro";
+        return id;
+      }
+    }
+  }
+
+  return id;
+}
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/keypad_advert.h
+++ b/components/switchbot_keypad_bridge/keypad_advert.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// SwitchBot keypad identification from a BLE advertisement.
+//
+// This is the project's equivalent of pySwitchbot's `adv_parser` keypad
+// detection: the model (and therefore the pairing protocol family) is read
+// straight from the SwitchBot service-data advertisement rather than from a
+// cloud SKU string. That makes detection independent of the ever-growing list
+// of cloud `device_type` codes — a new keypad works as long as it advertises a
+// recognised SwitchBot signature.
+//
+// The classifier is deliberately free of any NimBLE/cloud dependency: it takes
+// the raw 0xFD3D service-data bytes so the byte-matching logic stays in one
+// place and is trivial to reason about.
+
+#include <cstddef>
+#include <cstdint>
+
+#include "cloud_client.h"
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+struct KeypadIdent {
+  bool is_keypad{false};
+  CloudClient::KeypadFamily family{CloudClient::KeypadFamily::ORIGINAL};
+  const char *display_name{"Keypad"};
+};
+
+// Identify a SwitchBot keypad from the bytes of its 0xFD3D service-data
+// advertisement, mirroring pySwitchbot's SUPPORTED_TYPES signatures. Returns
+// `is_keypad == false` when the advert is empty or not a recognised keypad.
+KeypadIdent identify_keypad(const uint8_t *svc_data, size_t len);
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/keypad_pairer.cpp
+++ b/components/switchbot_keypad_bridge/keypad_pairer.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 
 #include "esphome/core/log.h"
+#include "keypad_advert.h"
 
 namespace esphome {
 namespace switchbot_keypad_bridge {
@@ -20,8 +21,8 @@ constexpr const char *SERVICE_UUID = "cba20d00-224d-11e6-9fb8-0002a5d5c51b";
 constexpr const char *RX_CHAR_UUID = "cba20002-224d-11e6-9fb8-0002a5d5c51b";
 constexpr const char *TX_CHAR_UUID = "cba20003-224d-11e6-9fb8-0002a5d5c51b";
 
-// Per-family pairing dialect. Direct port of KEYPAD_PRESETS in
-// tools/pair_keypad.py.
+// Per-family pairing dialect: the BLE handshake constants that differ
+// between the Original and Vision keypad families.
 struct FamilyPreset {
   uint8_t shared_slot;
   uint8_t slot_init_nonce;
@@ -101,13 +102,27 @@ bool aes_ctr_xcrypt(const uint8_t *key, const uint8_t iv[16],
   return s == PSA_SUCCESS;
 }
 
+// Read the SwitchBot service-data blob from an advertisement (UUID 0xFD3D,
+// with the legacy 0x0D00 as a fallback). Empty when the device isn't
+// advertising SwitchBot service data.
+std::vector<uint8_t> switchbot_service_data(const NimBLEAdvertisedDevice *adv) {
+  static const NimBLEUUID U_FD3D(static_cast<uint16_t>(0xFD3D));
+  static const NimBLEUUID U_0D00(static_cast<uint16_t>(0x0D00));
+  std::string sd = adv->getServiceData(U_FD3D);
+  if (sd.empty()) sd = adv->getServiceData(U_0D00);
+  return std::vector<uint8_t>(sd.begin(), sd.end());
+}
+
 // Briefly scan and look up the advertising packet of the target MAC so
 // we can connect with the right address type. The keypad's first byte
 // (top 2 bits = 11) makes it a BLE "random static" address; without a
 // scan we'd have to guess between PUBLIC and RANDOM. Returns the
 // address with the discovered type on success, an empty address on
-// timeout.
-NimBLEAddress discover_target(const std::string &mac_pretty, uint32_t timeout_ms) {
+// timeout. On success, `ident_out` carries the keypad model/family read
+// from the advertisement (pySwitchbot-style); `ident_out.is_keypad` is
+// false when the advert didn't match a known signature.
+NimBLEAddress discover_target(const std::string &mac_pretty, uint32_t timeout_ms,
+                             KeypadIdent &ident_out) {
   NimBLEScan *scan = NimBLEDevice::getScan();
   scan->clearResults();
   scan->setActiveScan(true);
@@ -127,7 +142,11 @@ NimBLEAddress discover_target(const std::string &mac_pretty, uint32_t timeout_ms
       if (c >= 'a' && c <= 'z') c = static_cast<char>(c - 'a' + 'A');
     }
     if (found == target) {
-      ESP_LOGI(TAG, "Found keypad %s (addr_type=%d)", mac_pretty.c_str(), adv->getAddressType());
+      const std::vector<uint8_t> sd = switchbot_service_data(adv);
+      ident_out = identify_keypad(sd.data(), sd.size());
+      ESP_LOGI(TAG, "Found keypad %s (addr_type=%d, advert=%s)",
+               mac_pretty.c_str(), adv->getAddressType(),
+               ident_out.is_keypad ? ident_out.display_name : "unrecognised");
       return adv->getAddress();
     }
   }
@@ -283,9 +302,8 @@ bool KeypadPairer::send_command_(NimBLERemoteCharacteristic *rx,
   if (!rx->writeValue(frame.data(), frame.size(), /*response=*/true)) {
     return false;
   }
-  // Wait briefly for the ACK notification. Like pair_keypad.py, we
-  // tolerate a missing ACK on most steps — the keypad doesn't always
-  // respond to the cosmetic commands.
+  // Wait briefly for the ACK notification. We tolerate a missing ACK on most
+  // steps — the keypad doesn't always respond to the cosmetic commands.
   xSemaphoreTake(this->ack_sem_, pdMS_TO_TICKS(800));
   return true;
 }
@@ -293,8 +311,6 @@ bool KeypadPairer::send_command_(NimBLERemoteCharacteristic *rx,
 // ── Task body ─────────────────────────────────────────────────────────────
 
 void KeypadPairer::execute_(Request &req) {
-  const FamilyPreset &preset = preset_for(req.family);
-
   // Step 0: discover the target via an active scan, then connect with
   // the correct address type. Without the scan we'd have to guess
   // between PUBLIC and RANDOM, and the BLE spec uses the top bits of
@@ -302,11 +318,23 @@ void KeypadPairer::execute_(Request &req) {
   // bytes, not the type. Scanning is also the natural check that the
   // keypad is in range right now.
   this->set_step_(0, STEP_LABELS[0]);
-  NimBLEAddress target = discover_target(req.keypad_mac, 6000);
+  KeypadIdent ident;
+  NimBLEAddress target = discover_target(req.keypad_mac, 6000, ident);
   if (target.isNull()) {
     this->set_failed_("Could not see the keypad over BLE. Keep it within 2 m and retry.");
     return;
   }
+
+  // The keypad model — and therefore the pairing dialect — comes solely from
+  // the live advertisement. If we can't identify it, we don't guess.
+  if (!ident.is_keypad) {
+    this->set_failed_("Could not identify the keypad from its advertisement. "
+                      "Reset it into pairing mode, keep it within 2 m and retry.");
+    return;
+  }
+  ESP_LOGI(TAG, "Pairing %s as %s family", ident.display_name,
+           ident.family == CloudClient::KeypadFamily::VISION ? "VISION" : "ORIGINAL");
+  const FamilyPreset &preset = preset_for(ident.family);
 
   // The keypad might currently be connected to our peripheral (server) role —
   // it sends IV requests to us as a SwitchBot Lock emulation. The BLE spec

--- a/components/switchbot_keypad_bridge/keypad_pairer.h
+++ b/components/switchbot_keypad_bridge/keypad_pairer.h
@@ -2,7 +2,7 @@
 
 // Background task that drives a single keypad↔ESP pairing session.
 //
-// Mirrors tools/pair_keypad.py's `_run_pairing` step by step:
+// Runs the pairing handshake step by step:
 //   1. Connect as BLE central to the keypad
 //   2. Subscribe to its TX characteristic
 //   3. Negotiate a session IV (`57 00 00 00 0F 21 03 <key_id>`)
@@ -59,12 +59,13 @@ class KeypadPairer {
     std::string job_id;        // matches the value returned by start()
   };
 
-  // Arguments for a single pairing attempt.
+  // Arguments for a single pairing attempt. The protocol family is NOT passed
+  // in — the pairer reads it from the keypad's live BLE advertisement during
+  // discovery (keypad_advert.h), which is the single source of truth.
   struct Request {
     std::string                  keypad_mac;       // pretty form, e.g. "B0:E9:FE:..."
     int                          key_id{0};        // 0x88 / 0xC6 / ... from cloud
     std::vector<uint8_t>         key;              // 16-byte AES-CTR key from cloud
-    CloudClient::KeypadFamily    family{CloudClient::KeypadFamily::ORIGINAL};
     std::array<uint8_t, 16>      shared_token{};   // the random key we inject
     std::array<uint8_t, 6>       esp_mac{};        // our BLE peripheral address
   };

--- a/components/switchbot_keypad_bridge/pairing_ui.cpp
+++ b/components/switchbot_keypad_bridge/pairing_ui.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "esphome/core/log.h"
+#include "keypad_advert.h"
 
 namespace esphome {
 namespace switchbot_keypad_bridge {
@@ -137,11 +138,29 @@ std::string extract_json_str(const std::string &body, const char *key) {
   return out;
 }
 
-// Active-scan for `duration_ms` and record the strongest RSSI seen for
-// each advertising address (upper-case, colon-separated). Lets the UI
-// flag which account keypads are actually reachable over BLE right now.
-std::map<std::string, int> scan_nearby(uint32_t duration_ms) {
-  std::map<std::string, int> seen;
+// One nearby BLE device: strongest RSSI seen plus its SwitchBot service-data
+// blob (so the UI can identify the keypad model the pySwitchbot way).
+struct NearbyDevice {
+  int rssi{0};
+  std::vector<uint8_t> svc_data;
+};
+
+// Read the SwitchBot service-data blob from an advertisement (UUID 0xFD3D,
+// with the legacy 0x0D00 as a fallback). Empty when not present.
+std::vector<uint8_t> switchbot_service_data(const NimBLEAdvertisedDevice *adv) {
+  static const NimBLEUUID U_FD3D(static_cast<uint16_t>(0xFD3D));
+  static const NimBLEUUID U_0D00(static_cast<uint16_t>(0x0D00));
+  std::string sd = adv->getServiceData(U_FD3D);
+  if (sd.empty()) sd = adv->getServiceData(U_0D00);
+  return std::vector<uint8_t>(sd.begin(), sd.end());
+}
+
+// Active-scan for `duration_ms` and record, for each advertising address
+// (upper-case, colon-separated), the strongest RSSI and its SwitchBot service
+// data. Lets the UI flag which account keypads are reachable right now and
+// identify their model straight from the advertisement.
+std::map<std::string, NearbyDevice> scan_nearby(uint32_t duration_ms) {
+  std::map<std::string, NearbyDevice> seen;
   NimBLEScan *scan = NimBLEDevice::getScan();
   scan->clearResults();
   scan->setActiveScan(true);
@@ -157,8 +176,11 @@ std::map<std::string, int> scan_nearby(uint32_t duration_ms) {
     }
     const int rssi = adv->getRSSI();
     auto it = seen.find(mac);
-    if (it == seen.end() || rssi > it->second) {
-      seen[mac] = rssi;
+    if (it == seen.end() || rssi > it->second.rssi) {
+      NearbyDevice &dev = seen[mac];
+      dev.rssi = rssi;
+      std::vector<uint8_t> sd = switchbot_service_data(adv);
+      if (!sd.empty()) dev.svc_data = std::move(sd);
     }
   }
   scan->clearResults();
@@ -200,31 +222,38 @@ esp_err_t PairingUi::handle_keypads_(httpd_req_t *req) {
     return reply_error_(req, "502 Bad Gateway", err);
   }
 
-  // Cross-reference the account keypads against a fresh BLE scan so the
-  // UI can show which ones are in range — and how strong the signal is.
-  const std::map<std::string, int> nearby = scan_nearby(4000);
+  // Cross-reference the account devices against a fresh BLE scan: this both
+  // shows which ones are in range (and how strong the signal is) and identifies
+  // the keypad model straight from the advertisement (pySwitchbot-style).
+  const std::map<std::string, NearbyDevice> nearby = scan_nearby(4000);
 
   std::string out = "[";
-  for (size_t i = 0; i < keypads.size(); ++i) {
-    const auto &k = keypads[i];
-    if (i != 0) out += ",";
+  unsigned shown = 0;
+  for (const auto &k : keypads) {
     const auto hit = nearby.find(k.mac_pretty);
-    const bool online = hit != nearby.end();
+    if (hit == nearby.end() || hit->second.svc_data.empty()) continue;
+
+    // A device is a keypad only if its live advertisement matches a known
+    // SwitchBot keypad signature. Everything else (locks, bots, hubs, …) and
+    // any out-of-range device is skipped — detection is BLE-only.
+    const KeypadIdent ident = identify_keypad(hit->second.svc_data.data(),
+                                              hit->second.svc_data.size());
+    if (!ident.is_keypad) continue;
+
+    if (shown++ != 0) out += ",";
     out += R"json({"mac":")json";
     out += json_escape(k.mac_pretty);
     out += R"json(","name":")json";
     out += json_escape(k.name);
     out += R"json(","model":")json";
-    out += json_escape(k.device_type);
-    out += R"json(","online":)json";
-    out += online ? "true" : "false";
-    out += R"json(,"rssi":)json";
-    out += online ? std::to_string(hit->second) : "null";
+    out += json_escape(ident.display_name);
+    out += R"json(","online":true,"rssi":)json";
+    out += std::to_string(hit->second.rssi);
     out += "}";
   }
   out += "]";
-  ESP_LOGI(TAG, "GET /api/keypads -> %u keypad(s), %u nearby",
-           static_cast<unsigned>(keypads.size()),
+  ESP_LOGI(TAG, "GET /api/keypads -> %u keypad(s) of %u account device(s), %u nearby",
+           shown, static_cast<unsigned>(keypads.size()),
            static_cast<unsigned>(nearby.size()));
   return reply_json_(req, out.c_str());
 }
@@ -258,7 +287,9 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
     return reply_error_(req, "401 Unauthorized", "Sign in first.");
   }
 
-  // Locate the keypad in the cached list so we know its family.
+  // Confirm the MAC belongs to this account (and grab its pretty form + name).
+  // The protocol family is determined later by the pairer from the keypad's
+  // live BLE advertisement.
   std::vector<CloudClient::AccountKeypad> keypads;
   std::string err;
   if (!self->cloud_.list_keypads(keypads, err)) {
@@ -290,7 +321,6 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   kr.keypad_mac  = found->mac_pretty;
   kr.key_id     = static_cast<int>(std::strtol(key_id_hex.c_str(), nullptr, 16));
   kr.key        = std::move(key_bytes);
-  kr.family     = found->family;
   kr.shared_token = self->shared_key_;
   kr.esp_mac = esp_ble_mac();
 

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
@@ -378,7 +378,7 @@ bool SwitchbotKeypadBridge::prepare_ble_() {
 // ---------------------------------------------------------------------------
 
 void SwitchbotKeypadBridge::on_rx_frame_(const std::string &frame) {
-  ESP_LOGV(TAG, "RX %zu bytes: %s", frame.size(),
+  ESP_LOGV(TAG, "RX WIRE %zu bytes: %s", frame.size(),
            format_hex_pretty(reinterpret_cast<const uint8_t *>(frame.data()), frame.size()).c_str());
 
   if (this->is_session_iv_request_(frame)) {
@@ -390,7 +390,7 @@ void SwitchbotKeypadBridge::on_rx_frame_(const std::string &frame) {
       ESP_LOGI(TAG, "Token slot: 0x%02X", requested_slot);
       this->shared_slot_id_ = requested_slot;
     }
-    ESP_LOGD(TAG, "IV request: key_id=0x%02X", requested_slot);
+    ESP_LOGD(TAG, "IV request");
     this->send_session_iv_();
     return;
   }
@@ -445,9 +445,11 @@ void SwitchbotKeypadBridge::on_rx_frame_(const std::string &frame) {
     return;  // error already logged
   }
 
+  ESP_LOGD(TAG, "RX %s", format_hex_pretty(plaintext, ct_len).c_str());
+
   DecodedCommand command;
   if (!this->decode_command_(plaintext, ct_len, command)) {
-    ESP_LOGD(TAG, "Unknown command payload: %s", format_hex_pretty(plaintext, ct_len).c_str());
+    ESP_LOGI(TAG, "Unhandled command: %s", format_hex_pretty(plaintext, ct_len).c_str());
     this->send_ack_(header);
     return;
   }
@@ -518,8 +520,9 @@ void SwitchbotKeypadBridge::handle_command_(const FrameHeader &header, const Dec
       return;
 
     case CommandType::UNLOCK:
-      ESP_LOGI(TAG, "Unlock command received (method=%s, index=%d)",
-               unlock_method_name(command.method), command.credential_index);
+      ESP_LOGI(TAG, "Unlock: method=%s (0x%02X) index=%d",
+               unlock_method_name(command.method),
+               static_cast<uint8_t>(command.method), command.credential_index);
       this->lock_state_ = LockState::UNLOCKED;
       this->publish_unlock_(command.method, command.credential_index);
       this->send_encrypted_response_(header, RESPONSE_UNLOCK, sizeof(RESPONSE_UNLOCK));


### PR DESCRIPTION
Closes #5 

The pairing wizard filtered account devices through a hardcoded exact-match SKU allowlist, so any keypad whose cloud device_type was not one of a few known strings was silently dropped. New SKUs keep appearing, so an allowlist is the wrong shape.

Identify the keypad model and protocol family the way the official pySwitchbot library does -- solely from the BLE advertisement service data (0xFD3D):

  first byte 'y' (0x79) ......... Keypad / Keypad Touch -> Original
  suffix ?? 11 03 78 ............ Keypad Vision          -> Vision
  suffix ?? 11 51 98 ............ Keypad Vision Pro       -> Vision

The cloud is now used only to enumerate the account's devices (MAC + name) and to fetch each keypad's communication key -- never to decide what a device is.

- New keypad_advert.{h,cpp}: pure byte-level classifier mirroring pySwitchbot.
- keypad_pairer: read the family from the target's live advert during discovery and select the pairing dialect from it; fail clearly if the advert can't be identified rather than guessing.
- cloud_client: remove the SKU table/classifier and the device_type field; list_keypads now returns every account device (MAC + name) as a candidate.
- pairing_ui: scan_nearby also captures SwitchBot service data; the keypad list shows a device only when its live advert matches a keypad signature.
- switchbot_keypad_bridge: clearer runtime debug logging (RX WIRE vs decoded RX, token slot, unhandled command, unlock method/index).

Tested on hardware: Keypad Vision pairs correctly via BLE detection.