### PR TITLE
feat: support Keypad Vision doorbell

### DIFF
--- a/components/switchbot_keypad_bridge/__init__.py
+++ b/components/switchbot_keypad_bridge/__init__.py
@@ -5,9 +5,10 @@ SwitchBot Keypad can deliver encrypted unlock/lock commands. The bridge
 decrypts the frames in-place using mbed-TLS / PSA Crypto and exposes the
 decoded commands through two surfaces:
 
-- A standard ESPHome ``event`` entity (``Lock``/``Unlock`` types).
-- ESPHome automation triggers (``on_lock`` / ``on_unlock``) which receive
-  the unlock ``method`` and credential ``index`` as arguments.
+- A standard ESPHome ``event`` entity (``Lock``/``Unlock``/``Doorbell`` types).
+- ESPHome automation triggers (``on_lock`` / ``on_unlock`` / ``on_doorbell``).
+  ``on_unlock`` receives the unlock ``method`` and credential ``index`` as
+  arguments; the others take none.
 
 The AES session key is generated on the device on first boot and kept in
 NVS — it is never part of the YAML configuration.
@@ -43,6 +44,7 @@ CONF_KEYPAD = "keypad"
 CONF_UNPAIR_BUTTON = "unpair_button"
 CONF_ON_LOCK = "on_lock"
 CONF_ON_UNLOCK = "on_unlock"
+CONF_ON_DOORBELL = "on_doorbell"
 CONF_PAIRING_UI = "pairing_ui"
 
 # Auto-generated id for the progmem array that carries the embedded UI.
@@ -63,6 +65,9 @@ LockTrigger = switchbot_keypad_bridge_ns.class_(
 )
 UnlockTrigger = switchbot_keypad_bridge_ns.class_(
     "UnlockTrigger", automation.Trigger.template(cg.std_string, cg.int_)
+)
+DoorbellTrigger = switchbot_keypad_bridge_ns.class_(
+    "DoorbellTrigger", automation.Trigger.template()
 )
 
 
@@ -103,6 +108,9 @@ CONFIG_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_ON_UNLOCK): automation.validate_automation(
             {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(UnlockTrigger)}
+        ),
+        cv.Optional(CONF_ON_DOORBELL): automation.validate_automation(
+            {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(DoorbellTrigger)}
         ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -158,7 +166,9 @@ async def to_code(config):
     await cg.register_component(var, config)
 
     if keypad_conf := config.get(CONF_KEYPAD_ACTION):
-        keypad = await event.new_event(keypad_conf, event_types=["Lock", "Unlock"])
+        keypad = await event.new_event(
+            keypad_conf, event_types=["Lock", "Unlock", "Doorbell"]
+        )
         cg.add(var.set_keypad_event(keypad))
 
     if keypad_sensor_conf := config.get(CONF_KEYPAD):
@@ -195,6 +205,10 @@ async def to_code(config):
         await automation.build_automation(
             trig, [(cg.std_string, "method"), (cg.int_, "index")], trig_conf
         )
+
+    for trig_conf in config.get(CONF_ON_DOORBELL, []):
+        trig = cg.new_Pvariable(trig_conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trig, [], trig_conf)
 
     # NimBLE C++ wrapper, pulled as ESP-IDF managed component (no Python deps).
     add_idf_component(

--- a/components/switchbot_keypad_bridge/automation.h
+++ b/components/switchbot_keypad_bridge/automation.h
@@ -21,5 +21,12 @@ class UnlockTrigger : public Trigger<std::string, int> {
   }
 };
 
+class DoorbellTrigger : public Trigger<> {
+ public:
+  explicit DoorbellTrigger(SwitchbotKeypadBridge *parent) {
+    parent->add_on_doorbell_callback([this]() { this->trigger(); });
+  }
+};
+
 }  // namespace switchbot_keypad_bridge
 }  // namespace esphome

--- a/components/switchbot_keypad_bridge/keypad_pairer.cpp
+++ b/components/switchbot_keypad_bridge/keypad_pairer.cpp
@@ -32,6 +32,8 @@ struct FamilyPreset {
   size_t capabilities_probe_len;
   const uint8_t *finalize_tail;
   size_t finalize_tail_len;
+  const uint8_t *enable_doorbell;     // may be nullptr (Vision-only feature)
+  size_t enable_doorbell_len;
 };
 
 constexpr uint8_t ORIGINAL_ENTER_PAIRING[]   = {0x0f, 0x52, 0x01, 0x07, 0x00};
@@ -41,17 +43,25 @@ constexpr uint8_t VISION_ENTER_PAIRING[]     = {0x0f, 0x53, 0x01, 0x07};
 constexpr uint8_t VISION_CAPABILITIES_PROBE[]= {0x0f, 0x53, 0x07, 0x03};
 constexpr uint8_t VISION_FINALIZE_TAIL[]     = {0x04, 0x04, 0x01, 0x05, 0x08, 0x09};
 
+// Doorbell-enable setting toggle (byte[4] = 0x02 enable / 0x01 disable),
+// captured from the official app. The app only exposes the toggle once a lock
+// is bound to the account, but the keypad firmware accepts the plain setting
+// write unconditionally. Vision-family only — Original/Touch have no doorbell.
+constexpr uint8_t VISION_ENABLE_DOORBELL[]   = {0x0f, 0x52, 0x01, 0x09, 0x02, 0x01, 0x01};
+
 constexpr FamilyPreset ORIGINAL_PRESET = {
     0x88, 0x69,
     ORIGINAL_ENTER_PAIRING,    sizeof(ORIGINAL_ENTER_PAIRING),
     nullptr,                   0,
     ORIGINAL_FINALIZE_TAIL,    sizeof(ORIGINAL_FINALIZE_TAIL),
+    nullptr,                   0,
 };
 constexpr FamilyPreset VISION_PRESET = {
     0xC6, 0x80,
     VISION_ENTER_PAIRING,      sizeof(VISION_ENTER_PAIRING),
     VISION_CAPABILITIES_PROBE, sizeof(VISION_CAPABILITIES_PROBE),
     VISION_FINALIZE_TAIL,      sizeof(VISION_FINALIZE_TAIL),
+    VISION_ENABLE_DOORBELL,    sizeof(VISION_ENABLE_DOORBELL),
 };
 
 const FamilyPreset &preset_for(CloudClient::KeypadFamily f) {
@@ -239,7 +249,7 @@ void KeypadPairer::set_running_(uint8_t total, const std::string &job_id) {
 }
 
 void KeypadPairer::set_step_(uint8_t step, const char *msg) {
-  ESP_LOGI(TAG, "step %u/%u: %s", static_cast<unsigned>(step + 1),
+  ESP_LOGI(TAG, "Step %u/%u: %s", static_cast<unsigned>(step + 1),
            static_cast<unsigned>(TOTAL_STEPS), msg);
   std::lock_guard<std::mutex> lk(this->mu_);
   this->status_.step    = step;
@@ -247,7 +257,7 @@ void KeypadPairer::set_step_(uint8_t step, const char *msg) {
 }
 
 void KeypadPairer::set_success_() {
-  ESP_LOGI(TAG, "pairing successful");
+  ESP_LOGI(TAG, "Pairing successful");
   std::lock_guard<std::mutex> lk(this->mu_);
   this->status_.state   = State::SUCCESS;
   this->status_.step    = this->status_.total;
@@ -256,7 +266,7 @@ void KeypadPairer::set_success_() {
 }
 
 void KeypadPairer::set_failed_(const std::string &err) {
-  ESP_LOGW(TAG, "pairing failed: %s", err.c_str());
+  ESP_LOGW(TAG, "Pairing failed: %s", err.c_str());
   std::lock_guard<std::mutex> lk(this->mu_);
   this->status_.state   = State::FAILED;
   this->status_.error   = err;
@@ -465,6 +475,13 @@ void KeypadPairer::execute_(Request &req) {
   }
   uint8_t finalize2[] = {0x0f, 0x53, 0x01, 0x06};
   this->send_command_(rx, finalize2, sizeof(finalize2));
+
+  // Enable the doorbell by default while we hold an authenticated session
+  // (Vision only). Best-effort: an unsupported keypad just ACKs and ignores it.
+  if (preset.enable_doorbell != nullptr) {
+    ESP_LOGI(TAG, "Enabling doorbell button");
+    this->send_command_(rx, preset.enable_doorbell, preset.enable_doorbell_len);
+  }
 
   // Cleanup.
   client->disconnect();

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
@@ -36,6 +36,9 @@ constexpr uint8_t ADVERTISING_MFG_DATA[] = {0x27, 0x09, 0x00, 0x10,
 constexpr uint8_t FRAME_LOCK[8]              = {0x0F, 0x4E, 0x01, 0x03, 0x00, 0x00, 0x00, 0x00};
 constexpr uint8_t FRAME_ACTION[4]            = {0x0F, 0x4E, 0x01, 0x03};
 constexpr uint8_t FRAME_STATE_POLL_PREFIX[3] = {0x0F, 0x4F, 0x81};
+// Doorbell press (Keypad Vision). A short, distinct 2-byte opcode the keypad
+// sends on the shared slot when its doorbell button is pressed.
+constexpr uint8_t FRAME_DOORBELL[2]          = {0x01, 0x03};
 
 // Encrypted response payloads sent back to the keypad on lock/unlock.
 constexpr uint8_t RESPONSE_LOCK[5]   = {0x90, 0x0A, 0x7F, 0x7F, 0x00};
@@ -49,7 +52,6 @@ constexpr uint8_t STATE_PAYLOAD_TAIL[13] = {0x08, 0x08, 0x41, 0x00, 0x00, 0x00, 
 constexpr uint8_t  PROTOCOL_MAGIC      = 0x57;
 constexpr size_t   ENCRYPTED_HEADER    = 4;     // [0x57, key_id, seq_a, seq_b]
 constexpr size_t   MAX_PAYLOAD_LEN     = 32;
-constexpr size_t   MIN_PAYLOAD_LEN     = 4;
 
 // Session IV negotiation: first frame received after connect.
 // Shape: 57 00 00 00 0F 21 03 <key_id>
@@ -188,7 +190,7 @@ void SwitchbotKeypadBridge::setup() {
   // so the very first pairing needs no button press.
   if (!have_keypad) {
     if (this->pairing_ui_.start()) {
-      ESP_LOGI(TAG, "No keypad paired — pairing mode active on http://<device>/");
+      ESP_LOGI(TAG, "No keypad paired — starting pairing mode");
     } else {
       ESP_LOGW(TAG, "Pairing UI failed to start; check port 80 is free");
     }
@@ -218,7 +220,7 @@ void SwitchbotKeypadBridge::loop() {
     // loop() runs on the main task.
     this->set_timeout(2000, [this]() {
       this->pairing_ui_.stop();
-      ESP_LOGI(TAG, "Pairing UI stopped — pairing complete");
+      ESP_LOGI(TAG, "Pairing UI stopped");
     });
   }
 
@@ -273,7 +275,7 @@ void SwitchbotKeypadBridge::unpair() {
   // Re-enter pairing mode straight away with the rotated key.
   this->pairing_ui_.set_shared_key(this->shared_key_);
   if (this->pairing_ui_.start()) {
-    ESP_LOGI(TAG, "Unpaired — pairing mode active on http://<device>/");
+    ESP_LOGI(TAG, "Unpaired — re-entering pairing mode");
   } else {
     ESP_LOGW(TAG, "Pairing UI failed to start; check port 80 is free");
   }
@@ -429,7 +431,7 @@ void SwitchbotKeypadBridge::on_rx_frame_(const std::string &frame) {
   }
 
   const size_t ct_len = frame.size() - ENCRYPTED_HEADER;
-  if (ct_len < MIN_PAYLOAD_LEN || ct_len > MAX_PAYLOAD_LEN) {
+  if (ct_len > MAX_PAYLOAD_LEN) {
     ESP_LOGW(TAG, "Dropping frame with invalid payload length: %zu", ct_len);
     return;
   }
@@ -494,6 +496,11 @@ bool SwitchbotKeypadBridge::decode_command_(const uint8_t *plaintext, size_t len
     out.type = CommandType::STATE_POLL;
     return true;
   }
+  if (length == sizeof(FRAME_DOORBELL) &&
+      std::memcmp(plaintext, FRAME_DOORBELL, sizeof(FRAME_DOORBELL)) == 0) {
+    out.type = CommandType::DOORBELL;
+    return true;
+  }
   if (length >= 8 && std::memcmp(plaintext, FRAME_ACTION, sizeof(FRAME_ACTION)) == 0 &&
       plaintext[UNLOCK_MARKER_OFFSET] == UNLOCK_MARKER) {
     out.type = CommandType::UNLOCK;
@@ -515,7 +522,7 @@ bool SwitchbotKeypadBridge::decode_command_(const uint8_t *plaintext, size_t len
 void SwitchbotKeypadBridge::handle_command_(const FrameHeader &header, const DecodedCommand &command) {
   switch (command.type) {
     case CommandType::LOCK:
-      ESP_LOGI(TAG, "Lock command received");
+      ESP_LOGI(TAG, "Lock");
       this->lock_state_ = LockState::LOCKED;
       this->publish_lock_();
       this->send_encrypted_response_(header, RESPONSE_LOCK, sizeof(RESPONSE_LOCK));
@@ -533,6 +540,13 @@ void SwitchbotKeypadBridge::handle_command_(const FrameHeader &header, const Dec
     case CommandType::STATE_POLL:
       ESP_LOGV(TAG, "State poll");
       this->handle_state_poll_(header);
+      return;
+
+    case CommandType::DOORBELL:
+      ESP_LOGI(TAG, "Doorbell");
+      this->publish_doorbell_();
+      // No lock-state change; the keypad only needs the transport ACK.
+      this->send_ack_(header);
       return;
 
     case CommandType::UNKNOWN:
@@ -672,6 +686,13 @@ void SwitchbotKeypadBridge::publish_unlock_(UnlockMethod method, int index) {
     this->keypad_event_->trigger("Unlock");
   }
   this->on_unlock_callbacks_.call(std::string(method_str), index);
+}
+
+void SwitchbotKeypadBridge::publish_doorbell_() {
+  if (this->keypad_event_ != nullptr) {
+    this->keypad_event_->trigger("Doorbell");
+  }
+  this->on_doorbell_callbacks_.call();
 }
 
 }  // namespace switchbot_keypad_bridge

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
@@ -74,6 +74,9 @@ class SwitchbotKeypadBridge : public Component {
   void add_on_unlock_callback(std::function<void(std::string, int)> &&callback) {
     this->on_unlock_callbacks_.add(std::move(callback));
   }
+  void add_on_doorbell_callback(std::function<void()> &&callback) {
+    this->on_doorbell_callbacks_.add(std::move(callback));
+  }
 
  protected:
   class ServerCallbacks;
@@ -91,6 +94,7 @@ class SwitchbotKeypadBridge : public Component {
     LOCK,
     UNLOCK,
     STATE_POLL,
+    DOORBELL,
   };
 
   // 4-byte transport header echoed back on every encrypted exchange.
@@ -150,6 +154,7 @@ class SwitchbotKeypadBridge : public Component {
 
   void publish_lock_();
   void publish_unlock_(UnlockMethod method, int index);
+  void publish_doorbell_();
 
   // ----- BLE handles ---------------------------------------------------------
 
@@ -187,6 +192,7 @@ class SwitchbotKeypadBridge : public Component {
   event::Event *keypad_event_{nullptr};
   CallbackManager<void()> on_lock_callbacks_{};
   CallbackManager<void(std::string, int)> on_unlock_callbacks_{};
+  CallbackManager<void()> on_doorbell_callbacks_{};
 
   // ----- User configuration --------------------------------------------------
 

--- a/switchbot-keypad-bridge.yaml
+++ b/switchbot-keypad-bridge.yaml
@@ -37,9 +37,6 @@ switchbot_keypad_bridge:
   unpair_button:
     name: "Unpair"
 
-  # on_lock:
-  #   - logger.log: "Locked"
-
   on_unlock:
     # method: "pin" | "fingerprint" | "nfc" | "face" | "unknown"   index: credential slot
     - homeassistant.event:
@@ -47,3 +44,9 @@ switchbot_keypad_bridge:
         data:
           method: !lambda 'return method;'
           index: !lambda 'return to_string(index);'
+  
+  # on_lock:
+  #   - logger.log: "Locked"
+
+  # on_doorbell:
+  #   - logger.log: "Doorbell pressed"


### PR DESCRIPTION
Closes #8 

Enable and surface the Keypad Vision doorbell button end to end.

Pairer (Vision only): after the commit step, send the doorbell-enable setting `0F 52 01 09 02 01 01` on the keypad credential key. The official app only exposes this toggle once a lock is bound to the account, but the keypad firmware accepts the plain setting write unconditionally, so we flip it on while we already hold an authenticated pairing session.

Bridge: a doorbell press arrives on the shared slot as the 2-byte opcode `01 03`. Decode it as CommandType::DOORBELL and expose it through the same three surfaces as lock/unlock - the `Doorbell` event type, the `on_doorbell` trigger, and (commented example) an `esphome.switchbot_keypad_doorbell` HA event. It carries no state change, so a bare transport ACK is the response.

Drop MIN_PAYLOAD_LEN: the old floor of 4 bytes silently dropped the 2-byte doorbell frame before it could be decrypted. The max-length cap is kept.

Also unify the command log lines to the bare action name (`Lock`, `Doorbell`, `Unlock: ...`), matching the event type names.