### PR TITLE
feat: keypad battery sensor + pairing/detection hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ lock.
 - 🔔 **Doorbell, no lock needed** — on Keypad Vision the doorbell button is
   enabled automatically during pairing (the app normally hides it until a lock
   is bound) and each press fires its own Home Assistant event.
+- 🔋 **Battery monitoring** — the keypad's battery level, exposed as a
+  diagnostic sensor.
 - 🔐 **Keys never leave the device** — the AES-128 session key is generated on
   the ESP32 and stored in NVS; it is never in your YAML or git.
 - 🧩 **Pure ESPHome** — exposes a standard `event` entity plus `on_lock` /
@@ -32,11 +34,10 @@ lock.
 
 ## Supported keypads
 
-The pairing wizard identifies the keypad model **from its BLE advertisement** —
-the same way the official [pySwitchbot](https://github.com/sblibs/pySwitchbot)
-library does — and adapts the pairing protocol accordingly. Detection does not
-depend on the cloud `device_type`/SKU string at all, so a keypad is found and
-paired even if its SKU is one SwitchBot hasn't shipped before.
+The wizard identifies the keypad model **from its BLE advertisement**
+(pySwitchbot-style) and adapts the pairing protocol accordingly. Detection
+never touches the cloud SKU string, so even a keypad with a brand-new SKU
+pairs fine.
 
 | Model | Protocol family | Status |
 |---|---|---|
@@ -103,57 +104,24 @@ Every `on_unlock` trigger carries two values:
 | `method` | `std::string` | `"pin"`, `"fingerprint"`, `"nfc"`, `"face"`, or `"unknown"` |
 | `index` | `int` | Numeric ID of the credential slot |
 
-**`index` is the slot the SwitchBot app assigns automatically when you add a
-PIN, fingerprint, NFC card, or face** — the first credential gets index `0`, the second
-`1`, and so on. Combined with `method`, it tells you exactly which family member
-is at the door.
+`index` is the slot the SwitchBot app assigns when you add a credential — first
+one gets `0`, the next `1`, and so on. Combined with `method`, it tells you
+exactly who is at the door.
 
-The cleanest pattern is to forward both values to Home Assistant as a custom
-event with `homeassistant.event`, then build per-user automations entirely in HA
-without recompiling the firmware:
+The cleanest pattern: forward both values to Home Assistant as a custom event
+and build per-user automations there, without recompiling the firmware:
 
 ```yaml
 switchbot_keypad_bridge:
-  keypad_action:
-    name: "Action"
-
   on_unlock:
-    # Forward method and index to Home Assistant as a custom event.
     - homeassistant.event:
         event: esphome.switchbot_keypad_unlock
         data:
           method: !lambda 'return method;'
           index: !lambda 'return to_string(index);'
-
-    # Or react directly on the ESP32 — e.g. a different action per user.
-    - if:
-        condition:
-          lambda: 'return method == "fingerprint" && index == 0;'
-        then:
-          - logger.log: "Welcome home, owner"
-
-  on_lock:
-    - logger.log: "Locked"
 ```
 
-On the Home Assistant side, create an automation (**Settings → Automations → New
-automation → ⋮ → Edit in YAML**) and paste:
-
-```yaml
-alias: Notify on keypad unlock
-triggers:
-  - trigger: event
-    event_type: esphome.switchbot_keypad_unlock
-actions:
-  - action: notify.mobile_app
-    data:
-      message: >
-        Door unlocked via {{ trigger.event.data.method }}
-        (credential #{{ trigger.event.data.index }})
-```
-
-To react only to a specific credential, add a `conditions:` block. This example
-fires only for the first fingerprint (index `0`):
+Then in Home Assistant, one automation per credential:
 
 ```yaml
 alias: Welcome home — owner fingerprint
@@ -171,42 +139,38 @@ actions:
       message: Welcome home!
 ```
 
-Create one automation per credential to send tailored notifications or trigger
-different actions for each family member.
-
 ## Doorbell (Keypad Vision)
 
-The Keypad Vision has a dedicated doorbell button. The official app only lets
-you enable it once a SwitchBot Lock is bound to your account — so the bridge
-turns it on for you, automatically, at the end of pairing. No lock required.
-
-Each press fires the `on_doorbell` trigger (no parameters) and a `Doorbell`
-event on the `event` entity. Forward it to Home Assistant the same way as an
-unlock:
+The official app hides the doorbell button until a SwitchBot Lock is bound to
+your account, so the bridge enables it automatically at the end of pairing.
+Each press fires the `on_doorbell` trigger and a `Doorbell` event:
 
 ```yaml
 switchbot_keypad_bridge:
-  keypad_action:
-    name: "Action"
-
   on_doorbell:
     - homeassistant.event:
         event: esphome.switchbot_keypad_doorbell
 ```
 
+> Vision family only — Original / Touch keypads have no doorbell button.
+
+## Keypad battery
+
+The keypad broadcasts its battery level in its BLE advertisement — the same
+source [pySwitchbot](https://github.com/sblibs/pySwitchbot) reads. Add the
+`battery_level` sensor and the bridge picks it up with a short background scan
+(every 15 minutes by default):
+
 ```yaml
-alias: Notify on keypad doorbell
-triggers:
-  - trigger: event
-    event_type: esphome.switchbot_keypad_doorbell
-actions:
-  - action: notify.mobile_app
-    data:
-      message: Someone's at the door
+switchbot_keypad_bridge:
+  battery_level:
+    name: "Keypad Battery"
+  battery_scan_interval: 15min
 ```
 
-> The doorbell button exists only on the Vision family; the option is skipped
-> for Original / Touch keypads, which have no doorbell.
+The scan targets the MAC saved at pairing time and is skipped while the keypad
+is connected or the wizard is busy. Keypads paired before this feature existed
+are adopted automatically from their advertisement — no re-pairing needed.
 
 ## Configuration reference
 
@@ -214,6 +178,8 @@ actions:
 |---|---|---|---|
 | `keypad_action` | event | no | Standard ESPHome `event` entity for keypad actions. Surfaces in HA as `event.<device>_action` with `Lock` / `Unlock` / `Doorbell` event types. |
 | `keypad` | text_sensor | no | Text sensor whose state is the display name of the paired keypad (Configuration category; empty if none). |
+| `battery_level` | sensor | no | Battery percentage of the paired keypad, read from its BLE advertisement (Diagnostic category). |
+| `battery_scan_interval` | time | no | How often the bridge scans for the keypad's advertisement to refresh `battery_level`. Default `15min`. |
 | `unpair_button` | button | no | Button that forgets the paired keypad, rotates the session key and re-opens the pairing wizard (no reboot). |
 | `on_lock` | automation | no | Triggered on every `lock` command. |
 | `on_unlock` | automation | no | Triggered on every `unlock` command — parameters `(std::string method, int index)`. |

--- a/components/switchbot_keypad_bridge/__init__.py
+++ b/components/switchbot_keypad_bridge/__init__.py
@@ -23,24 +23,34 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 import esphome.final_validate as fv
 from esphome import automation
-from esphome.components import button, event, text_sensor
+from esphome.components import button, event, sensor, text_sensor
 from esphome.components.esp32 import (
     add_idf_component,
     add_idf_sdkconfig_option,
     include_builtin_idf_component,
 )
-from esphome.const import CONF_ID, CONF_TRIGGER_ID, ENTITY_CATEGORY_CONFIG, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import (
+    CONF_BATTERY_LEVEL,
+    CONF_ID,
+    CONF_TRIGGER_ID,
+    DEVICE_CLASS_BATTERY,
+    ENTITY_CATEGORY_CONFIG,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_PERCENT,
+)
 from esphome.core import CORE, HexInt
 
 LOGGER = logging.getLogger(__name__)
 
 CODEOWNERS = ["@pierluigizagaria"]
 DEPENDENCIES = ["esp32"]
-AUTO_LOAD = ["event", "text_sensor", "button"]
+AUTO_LOAD = ["event", "text_sensor", "button", "sensor"]
 MULTI_CONF = False
 
 CONF_KEYPAD_ACTION = "keypad_action"
 CONF_KEYPAD = "keypad"
+CONF_BATTERY_SCAN_INTERVAL = "battery_scan_interval"
 CONF_UNPAIR_BUTTON = "unpair_button"
 CONF_ON_LOCK = "on_lock"
 CONF_ON_UNLOCK = "on_unlock"
@@ -96,6 +106,18 @@ CONFIG_SCHEMA = cv.Schema(
             icon="mdi:dialpad",
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
+        # The keypad broadcasts its battery in its BLE advertisement; the
+        # bridge picks it up with a short background scan once per interval.
+        cv.Optional(CONF_BATTERY_LEVEL): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            device_class=DEVICE_CLASS_BATTERY,
+            state_class=STATE_CLASS_MEASUREMENT,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            accuracy_decimals=0,
+        ),
+        cv.Optional(
+            CONF_BATTERY_SCAN_INTERVAL, default="15min"
+        ): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_PAIRING_UI): _deprecated_pairing_ui,
         cv.Optional(CONF_UNPAIR_BUTTON): button.button_schema(
             UnpairButton,
@@ -174,6 +196,15 @@ async def to_code(config):
     if keypad_sensor_conf := config.get(CONF_KEYPAD):
         sens = await text_sensor.new_text_sensor(keypad_sensor_conf)
         cg.add(var.set_keypad_text_sensor(sens))
+
+    if battery_conf := config.get(CONF_BATTERY_LEVEL):
+        batt = await sensor.new_sensor(battery_conf)
+        cg.add(var.set_battery_level_sensor(batt))
+        cg.add(
+            var.set_battery_scan_interval(
+                config[CONF_BATTERY_SCAN_INTERVAL].total_milliseconds
+            )
+        )
 
     if button_conf := config.get(CONF_UNPAIR_BUTTON):
         btn = await button.new_button(button_conf)

--- a/components/switchbot_keypad_bridge/__init__.py
+++ b/components/switchbot_keypad_bridge/__init__.py
@@ -16,6 +16,7 @@ NVS — it is never part of the YAML configuration.
 
 from __future__ import annotations
 
+import gzip
 import logging
 from pathlib import Path
 
@@ -218,10 +219,12 @@ async def to_code(config):
     cg.add_define("USE_WEBSERVER")
     cg.add_define("USE_WEBSERVER_PORT", 80)
 
-    # Bake the pairing wizard's HTML straight into the firmware image as a
-    # PROGMEM array. `pairing_ui.html` is the single source of truth — no
-    # generated header to commit, no build step to run by hand.
-    html_bytes = PAIRING_UI_HTML.read_bytes()
+    # Bake the pairing wizard's HTML into the firmware image as a
+    # gzip-compressed PROGMEM array (~4x smaller; served with
+    # Content-Encoding: gzip). `pairing_ui.html` is the single source of
+    # truth — no generated header to commit, no build step to run by hand.
+    # mtime=0 keeps the gzip header (and thus the build) reproducible.
+    html_bytes = gzip.compress(PAIRING_UI_HTML.read_bytes(), mtime=0)
     html_arr = cg.progmem_array(
         config[CONF_PAIRING_UI_HTML_ID], [HexInt(b) for b in html_bytes]
     )

--- a/components/switchbot_keypad_bridge/aes_ctr.cpp
+++ b/components/switchbot_keypad_bridge/aes_ctr.cpp
@@ -1,0 +1,59 @@
+#include "aes_ctr.h"
+
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+namespace {
+const char *const TAG = "switchbot_keypad_bridge.crypto";
+}  // namespace
+
+bool aes_ctr_xcrypt(psa_key_id_t key, const uint8_t iv[16],
+                    const uint8_t *input, uint8_t *output, size_t length) {
+  psa_cipher_operation_t op = PSA_CIPHER_OPERATION_INIT;
+  size_t out_len = 0;
+  size_t finish_len = 0;
+
+  psa_status_t status = psa_cipher_encrypt_setup(&op, key, PSA_ALG_CTR);
+  if (status == PSA_SUCCESS) {
+    status = psa_cipher_set_iv(&op, iv, 16);
+  }
+  if (status == PSA_SUCCESS) {
+    status = psa_cipher_update(&op, input, length, output, length, &out_len);
+  }
+  if (status == PSA_SUCCESS) {
+    status = psa_cipher_finish(&op, output + out_len, length - out_len, &finish_len);
+  }
+
+  if (status != PSA_SUCCESS) {
+    psa_cipher_abort(&op);
+    ESP_LOGE(TAG, "AES-CTR operation failed (%d)", static_cast<int>(status));
+    return false;
+  }
+  return true;
+}
+
+bool aes_ctr_xcrypt_raw_key(const uint8_t key[16], const uint8_t iv[16],
+                            const uint8_t *input, uint8_t *output, size_t length) {
+  psa_key_attributes_t attrs = PSA_KEY_ATTRIBUTES_INIT;
+  psa_set_key_usage_flags(&attrs, PSA_KEY_USAGE_ENCRYPT);
+  psa_set_key_algorithm(&attrs, PSA_ALG_CTR);
+  psa_set_key_type(&attrs, PSA_KEY_TYPE_AES);
+  psa_set_key_bits(&attrs, 128);
+
+  psa_key_id_t key_id = PSA_KEY_ID_NULL;
+  psa_status_t status = psa_import_key(&attrs, key, 16, &key_id);
+  psa_reset_key_attributes(&attrs);
+  if (status != PSA_SUCCESS) {
+    ESP_LOGE(TAG, "AES key import failed (%d)", static_cast<int>(status));
+    return false;
+  }
+
+  const bool ok = aes_ctr_xcrypt(key_id, iv, input, output, length);
+  psa_destroy_key(key_id);
+  return ok;
+}
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/aes_ctr.h
+++ b/components/switchbot_keypad_bridge/aes_ctr.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// AES-128-CTR on top of PSA Crypto — the one cipher the SwitchBot keypad
+// protocol uses. CTR is symmetric, so a single primitive covers both
+// encryption (responses) and decryption (incoming commands).
+
+#include <psa/crypto.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+// Run AES-128-CTR over `input` with an already-imported PSA key. `output`
+// must hold `length` bytes (in-place operation is not supported by PSA).
+// Logs and returns false on failure.
+bool aes_ctr_xcrypt(psa_key_id_t key, const uint8_t iv[16],
+                    const uint8_t *input, uint8_t *output, size_t length);
+
+// One-shot variant for a raw 16-byte key, imported and destroyed around the
+// call — the pairing path, where the keypad's cloud key only lives for the
+// duration of a single job.
+bool aes_ctr_xcrypt_raw_key(const uint8_t key[16], const uint8_t iv[16],
+                            const uint8_t *input, uint8_t *output, size_t length);
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/ble_utils.cpp
+++ b/components/switchbot_keypad_bridge/ble_utils.cpp
@@ -1,7 +1,5 @@
 #include "ble_utils.h"
 
-#include <cstdio>
-
 namespace esphome {
 namespace switchbot_keypad_bridge {
 
@@ -13,13 +11,6 @@ std::vector<uint8_t> switchbot_service_data(const NimBLEAdvertisedDevice *adv) {
   return std::vector<uint8_t>(sd.begin(), sd.end());
 }
 
-std::string upper_mac(std::string mac) {
-  for (auto &c : mac) {
-    if (c >= 'a' && c <= 'z') c = static_cast<char>(c - 'a' + 'A');
-  }
-  return mac;
-}
-
 std::array<uint8_t, 6> addr_bytes(const NimBLEAddress &addr) {
   std::array<uint8_t, 6> out{};
   const uint8_t *raw = addr.getBase()->val;  // little-endian
@@ -27,16 +18,6 @@ std::array<uint8_t, 6> addr_bytes(const NimBLEAddress &addr) {
     out[i] = raw[5 - i];
   }
   return out;
-}
-
-bool parse_mac_pretty(const std::string &mac, uint8_t out[6]) {
-  unsigned b[6];
-  if (std::sscanf(mac.c_str(), "%2x:%2x:%2x:%2x:%2x:%2x",
-                  &b[0], &b[1], &b[2], &b[3], &b[4], &b[5]) != 6) {
-    return false;
-  }
-  for (size_t i = 0; i < 6; ++i) out[i] = static_cast<uint8_t>(b[i]);
-  return true;
 }
 
 void configure_switchbot_scan(NimBLEScan *scan) {

--- a/components/switchbot_keypad_bridge/ble_utils.cpp
+++ b/components/switchbot_keypad_bridge/ble_utils.cpp
@@ -1,0 +1,50 @@
+#include "ble_utils.h"
+
+#include <cstdio>
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+std::vector<uint8_t> switchbot_service_data(const NimBLEAdvertisedDevice *adv) {
+  static const NimBLEUUID U_FD3D(static_cast<uint16_t>(0xFD3D));
+  static const NimBLEUUID U_0D00(static_cast<uint16_t>(0x0D00));
+  std::string sd = adv->getServiceData(U_FD3D);
+  if (sd.empty()) sd = adv->getServiceData(U_0D00);
+  return std::vector<uint8_t>(sd.begin(), sd.end());
+}
+
+std::string upper_mac(std::string mac) {
+  for (auto &c : mac) {
+    if (c >= 'a' && c <= 'z') c = static_cast<char>(c - 'a' + 'A');
+  }
+  return mac;
+}
+
+std::array<uint8_t, 6> addr_bytes(const NimBLEAddress &addr) {
+  std::array<uint8_t, 6> out{};
+  const uint8_t *raw = addr.getBase()->val;  // little-endian
+  for (size_t i = 0; i < 6; ++i) {
+    out[i] = raw[5 - i];
+  }
+  return out;
+}
+
+bool parse_mac_pretty(const std::string &mac, uint8_t out[6]) {
+  unsigned b[6];
+  if (std::sscanf(mac.c_str(), "%2x:%2x:%2x:%2x:%2x:%2x",
+                  &b[0], &b[1], &b[2], &b[3], &b[4], &b[5]) != 6) {
+    return false;
+  }
+  for (size_t i = 0; i < 6; ++i) out[i] = static_cast<uint8_t>(b[i]);
+  return true;
+}
+
+void configure_switchbot_scan(NimBLEScan *scan) {
+  scan->clearResults();
+  scan->setActiveScan(true);
+  scan->setInterval(45);
+  scan->setWindow(30);
+}
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/ble_utils.h
+++ b/components/switchbot_keypad_bridge/ble_utils.h
@@ -2,9 +2,9 @@
 
 // Small NimBLE helpers shared by the bridge, the pairer and the pairing UI.
 //
-// keypad_advert.h is deliberately NimBLE-free; everything here is the glue
-// between NimBLE types and that raw-bytes world (service-data extraction,
-// address formats, common scan parameters).
+// keypad_advert.h and mac_utils.h are deliberately NimBLE-free; everything
+// here is the glue between NimBLE types and that raw-bytes world
+// (service-data extraction, address bytes, common scan parameters).
 
 #include "nimble_compat.h"
 
@@ -20,15 +20,8 @@ namespace switchbot_keypad_bridge {
 // with the legacy 0x0D00 as a fallback). Empty when not present.
 std::vector<uint8_t> switchbot_service_data(const NimBLEAdvertisedDevice *adv);
 
-// Upper-cased copy of a MAC string, for case-insensitive comparisons
-// ("b0:e9:fe:…" → "B0:E9:FE:…").
-std::string upper_mac(std::string mac);
-
 // Address bytes in big-endian (printed) order — NimBLE stores them reversed.
 std::array<uint8_t, 6> addr_bytes(const NimBLEAddress &addr);
-
-// Parse "B0:E9:FE:11:22:33" (any case) into 6 big-endian bytes.
-bool parse_mac_pretty(const std::string &mac, uint8_t out[6]);
 
 // Apply the scan parameters every SwitchBot scan in this project uses, and
 // drop any previous results. Active scanning is required — the keypad's

--- a/components/switchbot_keypad_bridge/ble_utils.h
+++ b/components/switchbot_keypad_bridge/ble_utils.h
@@ -1,0 +1,47 @@
+#pragma once
+
+// Small NimBLE helpers shared by the bridge, the pairer and the pairing UI.
+//
+// keypad_advert.h is deliberately NimBLE-free; everything here is the glue
+// between NimBLE types and that raw-bytes world (service-data extraction,
+// address formats, common scan parameters).
+
+#include <NimBLEDevice.h>
+
+// NimBLE leaks LOG_LEVEL_* macros that collide with ESPHome's enum.
+#undef LOG_LEVEL_NONE
+#undef LOG_LEVEL_ERROR
+#undef LOG_LEVEL_WARN
+#undef LOG_LEVEL_INFO
+#undef LOG_LEVEL_DEBUG
+#undef LOG_LEVEL_CRITICAL
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+// Read the SwitchBot service-data blob from an advertisement (UUID 0xFD3D,
+// with the legacy 0x0D00 as a fallback). Empty when not present.
+std::vector<uint8_t> switchbot_service_data(const NimBLEAdvertisedDevice *adv);
+
+// Upper-cased copy of a MAC string, for case-insensitive comparisons
+// ("b0:e9:fe:…" → "B0:E9:FE:…").
+std::string upper_mac(std::string mac);
+
+// Address bytes in big-endian (printed) order — NimBLE stores them reversed.
+std::array<uint8_t, 6> addr_bytes(const NimBLEAddress &addr);
+
+// Parse "B0:E9:FE:11:22:33" (any case) into 6 big-endian bytes.
+bool parse_mac_pretty(const std::string &mac, uint8_t out[6]);
+
+// Apply the scan parameters every SwitchBot scan in this project uses, and
+// drop any previous results. Active scanning is required — the keypad's
+// 0xFD3D service data rides in the scan response.
+void configure_switchbot_scan(NimBLEScan *scan);
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/ble_utils.h
+++ b/components/switchbot_keypad_bridge/ble_utils.h
@@ -6,15 +6,7 @@
 // between NimBLE types and that raw-bytes world (service-data extraction,
 // address formats, common scan parameters).
 
-#include <NimBLEDevice.h>
-
-// NimBLE leaks LOG_LEVEL_* macros that collide with ESPHome's enum.
-#undef LOG_LEVEL_NONE
-#undef LOG_LEVEL_ERROR
-#undef LOG_LEVEL_WARN
-#undef LOG_LEVEL_INFO
-#undef LOG_LEVEL_DEBUG
-#undef LOG_LEVEL_CRITICAL
+#include "nimble_compat.h"
 
 #include <array>
 #include <cstdint>

--- a/components/switchbot_keypad_bridge/cloud_client.cpp
+++ b/components/switchbot_keypad_bridge/cloud_client.cpp
@@ -1,6 +1,5 @@
 #include "cloud_client.h"
 
-#include <cctype>
 #include <cstring>
 #include <ctime>
 
@@ -12,6 +11,7 @@
 #include <freertos/task.h>
 
 #include "esphome/core/log.h"
+#include "mac_utils.h"
 
 namespace esphome {
 namespace switchbot_keypad_bridge {
@@ -31,38 +31,6 @@ constexpr const char *ACCOUNT_BASE = "https://account.api.switchbot.net";
 // protocol family it speaks — is decided solely from its BLE advertisement, the
 // way the official pySwitchbot library does it (see keypad_advert.h). This keeps
 // us from chasing SwitchBot's ever-growing list of device_type codes.
-
-// Convert "B0E9FE612E75" → "B0:E9:FE:61:2E:75". Idempotent on already-
-// pretty input. Defensive on odd-length strings (returns input as-is).
-std::string pretty_mac(const std::string &raw) {
-  std::string compact;
-  compact.reserve(12);
-  for (char c : raw) {
-    if (c == ':' || c == '-')
-      continue;
-    compact.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
-  }
-  if (compact.size() != 12) return raw;
-  std::string out;
-  out.reserve(17);
-  for (size_t i = 0; i < 12; i += 2) {
-    if (!out.empty()) out.push_back(':');
-    out.push_back(compact[i]);
-    out.push_back(compact[i + 1]);
-  }
-  return out;
-}
-
-std::string compact_mac(const std::string &any) {
-  std::string out;
-  out.reserve(12);
-  for (char c : any) {
-    if (c == ':' || c == '-')
-      continue;
-    out.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
-  }
-  return out;
-}
 
 // Build the account-login request body. cJSON handles escaping, so a
 // password containing `"` or `\` is sent correctly rather than producing

--- a/components/switchbot_keypad_bridge/cloud_client.cpp
+++ b/components/switchbot_keypad_bridge/cloud_client.cpp
@@ -64,23 +64,21 @@ std::string compact_mac(const std::string &any) {
   return out;
 }
 
-// Build a JSON object string for the simple `{"k": "v", ...}` requests
-// we need.  Just enough to avoid pulling in a full JSON library on the
-// write side — we already use cJSON to read.
+// Build the account-login request body. cJSON handles escaping, so a
+// password containing `"` or `\` is sent correctly rather than producing
+// malformed JSON.
 std::string build_login_body(const std::string &email,
                              const std::string &password) {
-  // No JSON escaping for email/password — SwitchBot account emails and
-  // passwords realistically never contain `"` or `\`. If they do, login
-  // fails cleanly with an API error.
-  std::string body;
-  body.reserve(160 + email.size() + password.size());
-  body += R"json({"clientId":")json";
-  body += CLIENT_ID;
-  body += R"json(","username":")json";
-  body += email;
-  body += R"json(","password":")json";
-  body += password;
-  body += R"json(","grantType":"password","verifyCode":""})json";
+  cJSON *o = cJSON_CreateObject();
+  cJSON_AddStringToObject(o, "clientId", CLIENT_ID);
+  cJSON_AddStringToObject(o, "username", email.c_str());
+  cJSON_AddStringToObject(o, "password", password.c_str());
+  cJSON_AddStringToObject(o, "grantType", "password");
+  cJSON_AddStringToObject(o, "verifyCode", "");
+  char *s = cJSON_PrintUnformatted(o);
+  std::string body = (s != nullptr) ? s : "{}";
+  if (s != nullptr) cJSON_free(s);
+  cJSON_Delete(o);
   return body;
 }
 
@@ -95,21 +93,48 @@ esp_err_t http_event_handler(esp_http_client_event_t *evt) {
   return ESP_OK;
 }
 
-// cJSON convenience: parse and extract the body's `statusCode` (which
-// SwitchBot APIs always set to 100 on success). Returns the parsed
-// cJSON root on success; the caller must `cJSON_Delete` it.
-cJSON *parse_envelope(const std::string &body, int &status_code,
-                      std::string &message) {
-  cJSON *root = cJSON_ParseWithLength(body.data(), body.size());
-  if (root == nullptr) {
-    return nullptr;
+// Parsed SwitchBot API envelope. Every endpoint wraps its payload the same
+// way: `{"statusCode": 100, "message": "...", "body": {...}}`. The cJSON
+// tree is freed on scope exit, so error paths can simply return.
+class Envelope {
+ public:
+  explicit Envelope(const std::string &raw) {
+    this->root_ = cJSON_ParseWithLength(raw.data(), raw.size());
+    if (this->root_ == nullptr) return;
+    cJSON *sc = cJSON_GetObjectItemCaseSensitive(this->root_, "statusCode");
+    this->status_code_ = cJSON_IsNumber(sc) ? sc->valueint : -1;
+    cJSON *msg = cJSON_GetObjectItemCaseSensitive(this->root_, "message");
+    if (cJSON_IsString(msg) && msg->valuestring != nullptr) {
+      this->message_ = msg->valuestring;
+    }
   }
-  cJSON *sc = cJSON_GetObjectItemCaseSensitive(root, "statusCode");
-  status_code = cJSON_IsNumber(sc) ? sc->valueint : -1;
-  cJSON *msg = cJSON_GetObjectItemCaseSensitive(root, "message");
-  message = (cJSON_IsString(msg) && msg->valuestring) ? msg->valuestring : "";
-  return root;
-}
+  ~Envelope() {
+    if (this->root_ != nullptr) cJSON_Delete(this->root_);
+  }
+  Envelope(const Envelope &) = delete;
+  Envelope &operator=(const Envelope &) = delete;
+
+  bool is_json() const { return this->root_ != nullptr; }
+  // SwitchBot APIs set statusCode 100 on success.
+  bool ok() const { return this->is_json() && this->status_code_ == 100; }
+  // The API's own error message, or `fallback` when it didn't send one.
+  std::string error_or(const char *fallback) const {
+    return this->message_.empty() ? fallback : this->message_;
+  }
+  cJSON *body() const {
+    return this->is_json() ? cJSON_GetObjectItemCaseSensitive(this->root_, "body") : nullptr;
+  }
+  // Convenience: `body()[key]`, or nullptr anywhere along the way.
+  cJSON *body_item(const char *key) const {
+    cJSON *b = this->body();
+    return b != nullptr ? cJSON_GetObjectItemCaseSensitive(b, key) : nullptr;
+  }
+
+ private:
+  cJSON *root_{nullptr};
+  int status_code_{-1};
+  std::string message_;
+};
 
 bool parse_hex_byte(const char *s, uint8_t &out) {
   auto digit = [](char c) -> int {
@@ -229,27 +254,21 @@ bool CloudClient::login(const std::string &email, const std::string &password,
       return false;
     }
 
-    int sc = -1;
-    std::string msg;
-    cJSON *root = parse_envelope(response, sc, msg);
-    if (root == nullptr) {
+    Envelope env(response);
+    if (!env.is_json()) {
       error_out = "Login response was not valid JSON";
       return false;
     }
-    if (sc != 100) {
-      error_out = msg.empty() ? "Login rejected" : msg;
-      cJSON_Delete(root);
+    if (!env.ok()) {
+      error_out = env.error_or("Login rejected");
       return false;
     }
-    cJSON *body_obj = cJSON_GetObjectItemCaseSensitive(root, "body");
-    cJSON *tok = body_obj ? cJSON_GetObjectItemCaseSensitive(body_obj, "access_token") : nullptr;
+    cJSON *tok = env.body_item("access_token");
     if (!cJSON_IsString(tok) || tok->valuestring == nullptr) {
       error_out = "Login succeeded but no access_token returned";
-      cJSON_Delete(root);
       return false;
     }
     this->auth_token_ = tok->valuestring;
-    cJSON_Delete(root);
   }
 
   // Step 2: userinfo -> region. Failure here is non-fatal: we default
@@ -260,17 +279,11 @@ bool CloudClient::login(const std::string &email, const std::string &password,
     std::string response;
     std::string ignored_err;
     if (this->post_json_(url, "{}", this->auth_token_, response, ignored_err)) {
-      int sc = -1;
-      std::string msg;
-      cJSON *root = parse_envelope(response, sc, msg);
-      if (root != nullptr && sc == 100) {
-        cJSON *body_obj = cJSON_GetObjectItemCaseSensitive(root, "body");
-        cJSON *r = body_obj ? cJSON_GetObjectItemCaseSensitive(body_obj, "botRegion") : nullptr;
-        if (cJSON_IsString(r) && r->valuestring && r->valuestring[0] != '\0') {
-          this->region_ = r->valuestring;
-        }
+      Envelope env(response);
+      cJSON *r = env.ok() ? env.body_item("botRegion") : nullptr;
+      if (cJSON_IsString(r) && r->valuestring && r->valuestring[0] != '\0') {
+        this->region_ = r->valuestring;
       }
-      if (root != nullptr) cJSON_Delete(root);
     }
   }
 
@@ -278,14 +291,14 @@ bool CloudClient::login(const std::string &email, const std::string &password,
   return true;
 }
 
-bool CloudClient::list_keypads(std::vector<AccountKeypad> &out_keypads,
+bool CloudClient::list_devices(std::vector<AccountDevice> &out_devices,
                                std::string &error_out, bool force_refresh) {
   if (!this->is_logged_in()) {
     error_out = "Not logged in";
     return false;
   }
-  if (!force_refresh && !this->keypads_cache_.empty()) {
-    out_keypads = this->keypads_cache_;
+  if (!force_refresh && !this->devices_cache_.empty()) {
+    out_devices = this->devices_cache_;
     return true;
   }
 
@@ -296,50 +309,44 @@ bool CloudClient::list_keypads(std::vector<AccountKeypad> &out_keypads,
     return false;
   }
 
-  int sc = -1;
-  std::string msg;
-  cJSON *root = parse_envelope(response, sc, msg);
-  if (root == nullptr) {
+  Envelope env(response);
+  if (!env.is_json()) {
     error_out = "Device list response was not valid JSON";
     return false;
   }
-  if (sc != 100) {
-    error_out = msg.empty() ? "Device list rejected" : msg;
-    cJSON_Delete(root);
+  if (!env.ok()) {
+    error_out = env.error_or("Device list rejected");
     return false;
   }
 
-  cJSON *body_obj = cJSON_GetObjectItemCaseSensitive(root, "body");
-  cJSON *items = body_obj ? cJSON_GetObjectItemCaseSensitive(body_obj, "Items") : nullptr;
+  cJSON *items = env.body_item("Items");
   if (!cJSON_IsArray(items)) {
     error_out = "Device list missing Items array";
-    cJSON_Delete(root);
     return false;
   }
 
   // Return every account device that has a MAC. We don't classify here — the
   // pairing UI decides which of these are keypads purely from each device's
   // live BLE advertisement (see keypad_advert.h).
-  std::vector<AccountKeypad> picked;
+  std::vector<AccountDevice> picked;
   cJSON *item = nullptr;
   cJSON_ArrayForEach(item, items) {
     cJSON *mac = cJSON_GetObjectItemCaseSensitive(item, "device_mac");
     if (!cJSON_IsString(mac) || mac->valuestring == nullptr) continue;
     cJSON *name = cJSON_GetObjectItemCaseSensitive(item, "device_name");
 
-    AccountKeypad kp;
-    kp.mac          = compact_mac(mac->valuestring);
-    kp.mac_pretty   = pretty_mac(kp.mac);
-    kp.name         = (cJSON_IsString(name) && name->valuestring) ? name->valuestring
-                                                                   : kp.mac_pretty;
-    picked.push_back(std::move(kp));
+    AccountDevice dev;
+    dev.mac          = compact_mac(mac->valuestring);
+    dev.mac_pretty   = pretty_mac(dev.mac);
+    dev.name         = (cJSON_IsString(name) && name->valuestring) ? name->valuestring
+                                                                    : dev.mac_pretty;
+    picked.push_back(std::move(dev));
   }
-  cJSON_Delete(root);
 
   ESP_LOGI(TAG, "Account has %u device(s)", static_cast<unsigned>(picked.size()));
 
-  this->keypads_cache_ = picked;
-  out_keypads = std::move(picked);
+  this->devices_cache_ = picked;
+  out_devices = std::move(picked);
   return true;
 }
 
@@ -364,24 +371,19 @@ bool CloudClient::fetch_keypad_key(const std::string &mac,
     return false;
   }
 
-  int sc = -1;
-  std::string msg;
-  cJSON *root = parse_envelope(response, sc, msg);
-  if (root == nullptr) {
+  Envelope env(response);
+  if (!env.is_json()) {
     error_out = "communicate response was not valid JSON";
     return false;
   }
-  if (sc != 100) {
-    error_out = msg.empty() ? "communicate rejected" : msg;
-    cJSON_Delete(root);
+  if (!env.ok()) {
+    error_out = env.error_or("communicate rejected");
     return false;
   }
 
-  cJSON *body_obj = cJSON_GetObjectItemCaseSensitive(root, "body");
-  cJSON *ckey = body_obj ? cJSON_GetObjectItemCaseSensitive(body_obj, "communicationKey") : nullptr;
+  cJSON *ckey = env.body_item("communicationKey");
   if (!cJSON_IsObject(ckey)) {
     error_out = "communicate response missing communicationKey";
-    cJSON_Delete(root);
     return false;
   }
   cJSON *kid = cJSON_GetObjectItemCaseSensitive(ckey, "keyId");
@@ -389,17 +391,14 @@ bool CloudClient::fetch_keypad_key(const std::string &mac,
   if (!cJSON_IsString(kid) || !cJSON_IsString(k) ||
       kid->valuestring == nullptr || k->valuestring == nullptr) {
     error_out = "communicate response missing keyId/key";
-    cJSON_Delete(root);
     return false;
   }
 
   key_id_hex = kid->valuestring;
   if (!parse_hex_string(k->valuestring, key_bytes) || key_bytes.size() != 16) {
     error_out = "communicate returned a malformed AES key";
-    cJSON_Delete(root);
     return false;
   }
-  cJSON_Delete(root);
   return true;
 }
 

--- a/components/switchbot_keypad_bridge/cloud_client.h
+++ b/components/switchbot_keypad_bridge/cloud_client.h
@@ -28,19 +28,12 @@ namespace switchbot_keypad_bridge {
 
 class CloudClient {
  public:
-  // Pairing-protocol dialect. The SwitchBot Keypad firmware ships in two
-  // families with slightly different BLE handshakes ("original" and "vision").
-  // Which family a keypad speaks is identified from its BLE advertisement
-  // (see keypad_advert.h), not from any cloud field.
-  enum class KeypadFamily { ORIGINAL, VISION };
-
   // Plain-data view of one account device as returned by
-  // /wonder/device/v3/getdevice. `list_keypads` returns every account device
-  // that carries a MAC. Whether a device is a keypad — and which family it
-  // speaks — is decided by the pairing UI / pairer from its live BLE
-  // advertisement (keypad_advert.h); the cloud only supplies identity (MAC,
-  // name) and, later, the communication key.
-  struct AccountKeypad {
+  // /wonder/device/v3/getdevice. Whether a device is a keypad — and which
+  // family it speaks — is decided by the pairing UI / pairer from its live
+  // BLE advertisement (keypad_advert.h); the cloud only supplies identity
+  // (MAC, name) and, later, the communication key.
+  struct AccountDevice {
     std::string mac;          // hex, no separators: "B0E9FE612E75"
     std::string mac_pretty;   // "B0:E9:FE:61:2E:75"
     std::string name;         // user-set, e.g. "Keypad Vision 75"
@@ -56,7 +49,7 @@ class CloudClient {
   // candidates). The caller decides which are really keypads by checking each
   // one's live BLE advertisement (keypad_advert.h). Successive calls are
   // cached — pass `force_refresh = true` to bypass.
-  bool list_keypads(std::vector<AccountKeypad> &out_keypads,
+  bool list_devices(std::vector<AccountDevice> &out_devices,
                     std::string &error_out, bool force_refresh = false);
 
   // Look up a specific keypad's communication key. `mac` may be in
@@ -72,7 +65,7 @@ class CloudClient {
   void clear() {
     this->auth_token_.clear();
     this->region_.clear();
-    this->keypads_cache_.clear();
+    this->devices_cache_.clear();
   }
 
  private:
@@ -88,7 +81,7 @@ class CloudClient {
 
   std::string auth_token_;
   std::string region_;
-  std::vector<AccountKeypad> keypads_cache_;
+  std::vector<AccountDevice> devices_cache_;
 };
 
 }  // namespace switchbot_keypad_bridge

--- a/components/switchbot_keypad_bridge/keypad_advert.cpp
+++ b/components/switchbot_keypad_bridge/keypad_advert.cpp
@@ -35,7 +35,7 @@ KeypadIdent identify_keypad(const uint8_t *svc_data, size_t len) {
   // 1. First-byte match (low 7 bits) — Keypad / Keypad Touch (Original family).
   if ((svc_data[0] & 0x7F) == KEYPAD_TYPE_BYTE) {
     id.is_keypad = true;
-    id.family = CloudClient::KeypadFamily::ORIGINAL;
+    id.family = KeypadFamily::ORIGINAL;
     id.display_name = "Keypad";
     return id;
   }
@@ -47,13 +47,13 @@ KeypadIdent identify_keypad(const uint8_t *svc_data, size_t len) {
     for (const uint8_t *w : windows) {
       if (suffix_is(w, 0x11, 0x03, 0x78)) {
         id.is_keypad = true;
-        id.family = CloudClient::KeypadFamily::VISION;
+        id.family = KeypadFamily::VISION;
         id.display_name = "Keypad Vision";
         return id;
       }
       if (suffix_is(w, 0x11, 0x51, 0x98)) {
         id.is_keypad = true;
-        id.family = CloudClient::KeypadFamily::VISION;
+        id.family = KeypadFamily::VISION;
         id.display_name = "Keypad Vision Pro";
         return id;
       }
@@ -61,6 +61,22 @@ KeypadIdent identify_keypad(const uint8_t *svc_data, size_t len) {
   }
 
   return id;
+}
+
+int parse_keypad_battery(KeypadFamily family,
+                         const uint8_t *svc_data, size_t svc_len,
+                         const uint8_t *mfr_data, size_t mfr_len) {
+  if (family == KeypadFamily::ORIGINAL) {
+    if (svc_data == nullptr || svc_len < 3) return -1;
+    return svc_data[2] & 0x7F;
+  }
+
+  // VISION: pySwitchbot reads mfr_data[7], where mfr_data is the payload
+  // after the company id — the raw AD blob therefore carries it at byte 9,
+  // behind the little-endian SwitchBot company id (0x69 0x09).
+  if (mfr_data == nullptr || mfr_len < 10) return -1;
+  if (mfr_data[0] != 0x69 || mfr_data[1] != 0x09) return -1;
+  return mfr_data[9] & 0x7F;
 }
 
 }  // namespace switchbot_keypad_bridge

--- a/components/switchbot_keypad_bridge/keypad_advert.cpp
+++ b/components/switchbot_keypad_bridge/keypad_advert.cpp
@@ -1,7 +1,18 @@
 #include "keypad_advert.h"
 
+#include <cstring>
+
 namespace esphome {
 namespace switchbot_keypad_bridge {
+
+const char *keypad_family_str(KeypadFamily family) {
+  return family == KeypadFamily::VISION ? "vision" : "original";
+}
+
+KeypadFamily keypad_family_from_str(const char *s) {
+  return (s != nullptr && std::strcmp(s, "vision") == 0) ? KeypadFamily::VISION
+                                                         : KeypadFamily::ORIGINAL;
+}
 
 namespace {
 
@@ -36,25 +47,18 @@ KeypadIdent identify_keypad(const uint8_t *svc_data, size_t len) {
   if ((svc_data[0] & 0x7F) == KEYPAD_TYPE_BYTE) {
     id.is_keypad = true;
     id.family = KeypadFamily::ORIGINAL;
-    id.display_name = "Keypad";
     return id;
   }
 
-  // 2. Trailing 4-byte window — Vision / Vision Pro (Vision family). Try both
-  //    the last-4 and the next-to-last-4 windows, as pySwitchbot does.
+  // 2. Trailing 4-byte window — Keypad Vision (?? 11 03 78) and Keypad Vision
+  //    Pro (?? 11 51 98), both the Vision family. Try the last-4 and the
+  //    next-to-last-4 windows, as pySwitchbot does.
   if (len > 5) {
     const uint8_t *windows[] = {svc_data + (len - 4), svc_data + (len - 5)};
     for (const uint8_t *w : windows) {
-      if (suffix_is(w, 0x11, 0x03, 0x78)) {
+      if (suffix_is(w, 0x11, 0x03, 0x78) || suffix_is(w, 0x11, 0x51, 0x98)) {
         id.is_keypad = true;
         id.family = KeypadFamily::VISION;
-        id.display_name = "Keypad Vision";
-        return id;
-      }
-      if (suffix_is(w, 0x11, 0x51, 0x98)) {
-        id.is_keypad = true;
-        id.family = KeypadFamily::VISION;
-        id.display_name = "Keypad Vision Pro";
         return id;
       }
     }

--- a/components/switchbot_keypad_bridge/keypad_advert.h
+++ b/components/switchbot_keypad_bridge/keypad_advert.h
@@ -16,14 +16,18 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "cloud_client.h"
-
 namespace esphome {
 namespace switchbot_keypad_bridge {
 
+// Pairing-protocol dialect. The SwitchBot Keypad firmware ships in two
+// families with slightly different BLE handshakes ("original" and "vision").
+// Which family a keypad speaks is identified right here, from its BLE
+// advertisement — never from any cloud field.
+enum class KeypadFamily : uint8_t { ORIGINAL, VISION };
+
 struct KeypadIdent {
   bool is_keypad{false};
-  CloudClient::KeypadFamily family{CloudClient::KeypadFamily::ORIGINAL};
+  KeypadFamily family{KeypadFamily::ORIGINAL};
   const char *display_name{"Keypad"};
 };
 
@@ -31,6 +35,20 @@ struct KeypadIdent {
 // advertisement, mirroring pySwitchbot's SUPPORTED_TYPES signatures. Returns
 // `is_keypad == false` when the advert is empty or not a recognised keypad.
 KeypadIdent identify_keypad(const uint8_t *svc_data, size_t len);
+
+// Extract the keypad's battery percentage from its BLE advertisement,
+// mirroring pySwitchbot's adv_parsers:
+//
+//   ORIGINAL (process_wokeypad) ......... service-data byte 2, low 7 bits
+//   VISION (process_keypad_vision[_pro])  manufacturer-data byte 7 after the
+//                                         2-byte company id, low 7 bits
+//
+// `mfr_data` is the raw manufacturer-specific AD payload, company id
+// included (little-endian 0x0969 for SwitchBot). Returns -1 when the
+// advertisement does not carry the field.
+int parse_keypad_battery(KeypadFamily family,
+                         const uint8_t *svc_data, size_t svc_len,
+                         const uint8_t *mfr_data, size_t mfr_len);
 
 }  // namespace switchbot_keypad_bridge
 }  // namespace esphome

--- a/components/switchbot_keypad_bridge/keypad_advert.h
+++ b/components/switchbot_keypad_bridge/keypad_advert.h
@@ -25,10 +25,15 @@ namespace switchbot_keypad_bridge {
 // advertisement — never from any cloud field.
 enum class KeypadFamily : uint8_t { ORIGINAL, VISION };
 
+// Stable wire names for the family, used to carry it between the pairing UI
+// and the firmware. `keypad_family_from_str` falls back to ORIGINAL for any
+// unrecognised input.
+const char *keypad_family_str(KeypadFamily family);
+KeypadFamily keypad_family_from_str(const char *s);
+
 struct KeypadIdent {
   bool is_keypad{false};
   KeypadFamily family{KeypadFamily::ORIGINAL};
-  const char *display_name{"Keypad"};
 };
 
 // Identify a SwitchBot keypad from the bytes of its 0xFD3D service-data

--- a/components/switchbot_keypad_bridge/keypad_pairer.cpp
+++ b/components/switchbot_keypad_bridge/keypad_pairer.cpp
@@ -71,8 +71,9 @@ const FamilyPreset &preset_for(KeypadFamily f) {
 }
 
 // Friendly step labels — kept short so the UI's progress card stays tidy.
-// Keep these in lock-step with the <ul class="stepper"> list in
-// pairing_ui.html: same count, same order, same wording.
+// The wizard fetches these through step_count()/step_label() (via the
+// /api/pair response) and builds its stepper from them, so this list is
+// the single source of truth for count, order and wording.
 constexpr const char *STEP_LABELS[] = {
     "Connecting to keypad",
     "Discovering services",
@@ -118,6 +119,12 @@ NimBLEAddress discover_target(const std::string &mac_pretty, uint32_t timeout_ms
 }  // namespace
 
 // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+uint8_t KeypadPairer::step_count() { return TOTAL_STEPS; }
+
+const char *KeypadPairer::step_label(uint8_t step) {
+  return step < TOTAL_STEPS ? STEP_LABELS[step] : "";
+}
 
 std::string KeypadPairer::start(Request req) {
   {

--- a/components/switchbot_keypad_bridge/keypad_pairer.cpp
+++ b/components/switchbot_keypad_bridge/keypad_pairer.cpp
@@ -1,12 +1,13 @@
 #include "keypad_pairer.h"
 
 #include <host/ble_gap.h>
-#include <psa/crypto.h>
 
 #include <cstdio>
 #include <cstring>
 
 #include "esphome/core/log.h"
+#include "aes_ctr.h"
+#include "ble_utils.h"
 #include "keypad_advert.h"
 
 namespace esphome {
@@ -64,8 +65,8 @@ constexpr FamilyPreset VISION_PRESET = {
     VISION_ENABLE_DOORBELL,    sizeof(VISION_ENABLE_DOORBELL),
 };
 
-const FamilyPreset &preset_for(CloudClient::KeypadFamily f) {
-  return f == CloudClient::KeypadFamily::VISION ? VISION_PRESET : ORIGINAL_PRESET;
+const FamilyPreset &preset_for(KeypadFamily f) {
+  return f == KeypadFamily::VISION ? VISION_PRESET : ORIGINAL_PRESET;
 }
 
 // Friendly step labels — kept short so the UI's progress card stays tidy.
@@ -83,46 +84,6 @@ constexpr const char *STEP_LABELS[] = {
 };
 constexpr uint8_t TOTAL_STEPS = sizeof(STEP_LABELS) / sizeof(STEP_LABELS[0]);
 
-// AES-128-CTR via PSA Crypto. The keypad K14 only lives for the
-// duration of one pairing run, so we import the key fresh each time
-// and destroy it at the end of the call.  Same primitive the runtime
-// decrypt path uses — no extra IDF component dependency.
-bool aes_ctr_xcrypt(const uint8_t *key, const uint8_t iv[16],
-                    const uint8_t *in, uint8_t *out, size_t length) {
-  psa_key_attributes_t attrs = PSA_KEY_ATTRIBUTES_INIT;
-  psa_set_key_usage_flags(&attrs, PSA_KEY_USAGE_ENCRYPT);
-  psa_set_key_algorithm(&attrs, PSA_ALG_CTR);
-  psa_set_key_type(&attrs, PSA_KEY_TYPE_AES);
-  psa_set_key_bits(&attrs, 128);
-
-  psa_key_id_t key_id = PSA_KEY_ID_NULL;
-  psa_status_t s = psa_import_key(&attrs, key, 16, &key_id);
-  psa_reset_key_attributes(&attrs);
-  if (s != PSA_SUCCESS) return false;
-
-  psa_cipher_operation_t op = PSA_CIPHER_OPERATION_INIT;
-  size_t out_len = 0, finish_len = 0;
-  s = psa_cipher_encrypt_setup(&op, key_id, PSA_ALG_CTR);
-  if (s == PSA_SUCCESS) s = psa_cipher_set_iv(&op, iv, 16);
-  if (s == PSA_SUCCESS) s = psa_cipher_update(&op, in, length, out, length, &out_len);
-  if (s == PSA_SUCCESS) s = psa_cipher_finish(&op, out + out_len, length - out_len, &finish_len);
-  if (s != PSA_SUCCESS) psa_cipher_abort(&op);
-
-  psa_destroy_key(key_id);
-  return s == PSA_SUCCESS;
-}
-
-// Read the SwitchBot service-data blob from an advertisement (UUID 0xFD3D,
-// with the legacy 0x0D00 as a fallback). Empty when the device isn't
-// advertising SwitchBot service data.
-std::vector<uint8_t> switchbot_service_data(const NimBLEAdvertisedDevice *adv) {
-  static const NimBLEUUID U_FD3D(static_cast<uint16_t>(0xFD3D));
-  static const NimBLEUUID U_0D00(static_cast<uint16_t>(0x0D00));
-  std::string sd = adv->getServiceData(U_FD3D);
-  if (sd.empty()) sd = adv->getServiceData(U_0D00);
-  return std::vector<uint8_t>(sd.begin(), sd.end());
-}
-
 // Briefly scan and look up the advertising packet of the target MAC so
 // we can connect with the right address type. The keypad's first byte
 // (top 2 bits = 11) makes it a BLE "random static" address; without a
@@ -134,24 +95,14 @@ std::vector<uint8_t> switchbot_service_data(const NimBLEAdvertisedDevice *adv) {
 NimBLEAddress discover_target(const std::string &mac_pretty, uint32_t timeout_ms,
                              KeypadIdent &ident_out) {
   NimBLEScan *scan = NimBLEDevice::getScan();
-  scan->clearResults();
-  scan->setActiveScan(true);
-  scan->setInterval(45);
-  scan->setWindow(30);
+  configure_switchbot_scan(scan);
 
-  std::string target = mac_pretty;
-  for (auto &c : target) {
-    if (c >= 'a' && c <= 'z') c = static_cast<char>(c - 'a' + 'A');
-  }
+  const std::string target = upper_mac(mac_pretty);
 
   NimBLEScanResults results = scan->getResults(timeout_ms, false);
   for (int i = 0; i < results.getCount(); ++i) {
     const NimBLEAdvertisedDevice *adv = results.getDevice(i);
-    std::string found = adv->getAddress().toString();
-    for (auto &c : found) {
-      if (c >= 'a' && c <= 'z') c = static_cast<char>(c - 'a' + 'A');
-    }
-    if (found == target) {
+    if (upper_mac(adv->getAddress().toString()) == target) {
       const std::vector<uint8_t> sd = switchbot_service_data(adv);
       ident_out = identify_keypad(sd.data(), sd.size());
       ESP_LOGI(TAG, "Found keypad %s (addr_type=%d, advert=%s)",
@@ -256,13 +207,16 @@ void KeypadPairer::set_step_(uint8_t step, const char *msg) {
   this->status_.message = msg;
 }
 
-void KeypadPairer::set_success_() {
+void KeypadPairer::set_success_(const std::string &keypad_mac,
+                                KeypadFamily family) {
   ESP_LOGI(TAG, "Pairing successful");
   std::lock_guard<std::mutex> lk(this->mu_);
-  this->status_.state   = State::SUCCESS;
-  this->status_.step    = this->status_.total;
-  this->status_.message = "Pairing complete";
+  this->status_.state      = State::SUCCESS;
+  this->status_.step       = this->status_.total;
+  this->status_.message    = "Pairing complete";
   this->status_.error.clear();
+  this->status_.keypad_mac = keypad_mac;
+  this->status_.family     = family;
 }
 
 void KeypadPairer::set_failed_(const std::string &err) {
@@ -297,13 +251,15 @@ bool KeypadPairer::send_command_(NimBLERemoteCharacteristic *rx,
                                  const uint8_t *plaintext, size_t plaintext_len) {
   // Encrypted frame layout (same as the existing keypad command path):
   //   [0x57][key_id][IV[0]][IV[1]][AES-CTR(K14, IV, plaintext)]
+  // The keypad's K14 only lives for the duration of one pairing run, so it
+  // is imported fresh for each frame and destroyed right after.
   std::vector<uint8_t> frame(4 + plaintext_len);
   frame[0] = 0x57;
   frame[1] = this->key_id_;
   frame[2] = this->iv_[0];
   frame[3] = this->iv_[1];
-  if (!aes_ctr_xcrypt(this->key_.data(), this->iv_.data(),
-                      plaintext, frame.data() + 4, plaintext_len)) {
+  if (!aes_ctr_xcrypt_raw_key(this->key_.data(), this->iv_.data(),
+                              plaintext, frame.data() + 4, plaintext_len)) {
     return false;
   }
 
@@ -343,7 +299,7 @@ void KeypadPairer::execute_(Request &req) {
     return;
   }
   ESP_LOGI(TAG, "Pairing %s as %s family", ident.display_name,
-           ident.family == CloudClient::KeypadFamily::VISION ? "VISION" : "ORIGINAL");
+           ident.family == KeypadFamily::VISION ? "VISION" : "ORIGINAL");
   const FamilyPreset &preset = preset_for(ident.family);
 
   // The keypad might currently be connected to our peripheral (server) role —
@@ -487,7 +443,7 @@ void KeypadPairer::execute_(Request &req) {
   client->disconnect();
   NimBLEDevice::deleteClient(client);
 
-  this->set_success_();
+  this->set_success_(req.keypad_mac, ident.family);
 }
 
 }  // namespace switchbot_keypad_bridge

--- a/components/switchbot_keypad_bridge/keypad_pairer.cpp
+++ b/components/switchbot_keypad_bridge/keypad_pairer.cpp
@@ -9,6 +9,7 @@
 #include "aes_ctr.h"
 #include "ble_utils.h"
 #include "keypad_advert.h"
+#include "mac_utils.h"
 
 namespace esphome {
 namespace switchbot_keypad_bridge {

--- a/components/switchbot_keypad_bridge/keypad_pairer.cpp
+++ b/components/switchbot_keypad_bridge/keypad_pairer.cpp
@@ -393,13 +393,23 @@ void KeypadPairer::execute_(Request &req) {
     this->set_failed_("enter_pairing rejected.");
     return;
   }
+  // Best-effort pair of frames: the capabilities probe is informational and
+  // the prep preamble is tolerated missing by every keypad we've captured.
   if (preset.capabilities_probe != nullptr) {
     this->send_command_(rx, preset.capabilities_probe, preset.capabilities_probe_len);
   }
   uint8_t prep[] = {0x06, 0x03};
   this->send_command_(rx, prep, sizeof(prep));
+  // slot_init is NOT best-effort: it opens the slot the shared key is written
+  // into on steps 4-5. Carrying on after a failed write would report SUCCESS
+  // for a keypad that never works.
   uint8_t slot_init[] = {0x0F, 0x20, 0x03, preset.shared_slot, preset.slot_init_nonce};
-  this->send_command_(rx, slot_init, sizeof(slot_init));
+  if (!this->send_command_(rx, slot_init, sizeof(slot_init))) {
+    client->disconnect();
+    NimBLEDevice::deleteClient(client);
+    this->set_failed_("Could not open the keypad's key slot.");
+    return;
+  }
 
   // Step 4: shared_key chunk 1.
   uint8_t tok1[5 + 8];

--- a/components/switchbot_keypad_bridge/keypad_pairer.cpp
+++ b/components/switchbot_keypad_bridge/keypad_pairer.cpp
@@ -74,6 +74,10 @@ const FamilyPreset &preset_for(KeypadFamily f) {
 // The wizard fetches these through step_count()/step_label() (via the
 // /api/pair response) and builds its stepper from them, so this list is
 // the single source of truth for count, order and wording.
+//
+// The first BASE_STEP_COUNT entries are common to every family; the trailing
+// "Enabling doorbell" step exists only on the Vision family (Original/Touch
+// keypads have no doorbell).
 constexpr const char *STEP_LABELS[] = {
     "Connecting to keypad",
     "Discovering services",
@@ -83,8 +87,11 @@ constexpr const char *STEP_LABELS[] = {
     "Writing shared key (2/2)",
     "Updating lock target",
     "Finalising",
+    "Force-enabling doorbell",  // Vision-only
 };
-constexpr uint8_t TOTAL_STEPS = sizeof(STEP_LABELS) / sizeof(STEP_LABELS[0]);
+constexpr uint8_t BASE_STEP_COUNT   = 8;   // steps 0..7, every family
+constexpr uint8_t DOORBELL_STEP      = 8;   // index of the Vision-only step
+constexpr uint8_t VISION_STEP_COUNT = 9;   // base + doorbell
 
 // Briefly scan and look up the advertising packet of the target MAC so
 // we can connect with the right address type. The keypad's first byte
@@ -109,7 +116,7 @@ NimBLEAddress discover_target(const std::string &mac_pretty, uint32_t timeout_ms
       ident_out = identify_keypad(sd.data(), sd.size());
       ESP_LOGI(TAG, "Found keypad %s (addr_type=%d, advert=%s)",
                mac_pretty.c_str(), adv->getAddressType(),
-               ident_out.is_keypad ? ident_out.display_name : "unrecognised");
+               ident_out.is_keypad ? keypad_family_str(ident_out.family) : "unrecognised");
       return adv->getAddress();
     }
   }
@@ -120,10 +127,12 @@ NimBLEAddress discover_target(const std::string &mac_pretty, uint32_t timeout_ms
 
 // ── Lifecycle ─────────────────────────────────────────────────────────────
 
-uint8_t KeypadPairer::step_count() { return TOTAL_STEPS; }
+uint8_t KeypadPairer::step_count(KeypadFamily family) {
+  return family == KeypadFamily::VISION ? VISION_STEP_COUNT : BASE_STEP_COUNT;
+}
 
-const char *KeypadPairer::step_label(uint8_t step) {
-  return step < TOTAL_STEPS ? STEP_LABELS[step] : "";
+const char *KeypadPairer::step_label(KeypadFamily family, uint8_t step) {
+  return step < step_count(family) ? STEP_LABELS[step] : "";
 }
 
 std::string KeypadPairer::start(Request req) {
@@ -156,7 +165,7 @@ std::string KeypadPairer::start(Request req) {
   }
   while (xSemaphoreTake(this->ack_sem_, 0) == pdTRUE) { /* drain */ }
 
-  this->set_running_(TOTAL_STEPS, job_id);
+  this->set_running_(step_count(req_heap->family), job_id);
 
   // Spawn the task. The trampoline forwards to execute_() and frees the
   // request when done.
@@ -208,9 +217,9 @@ void KeypadPairer::set_running_(uint8_t total, const std::string &job_id) {
 }
 
 void KeypadPairer::set_step_(uint8_t step, const char *msg) {
-  ESP_LOGI(TAG, "Step %u/%u: %s", static_cast<unsigned>(step + 1),
-           static_cast<unsigned>(TOTAL_STEPS), msg);
   std::lock_guard<std::mutex> lk(this->mu_);
+  ESP_LOGI(TAG, "Step %u/%u: %s", static_cast<unsigned>(step + 1),
+           static_cast<unsigned>(this->status_.total), msg);
   this->status_.step    = step;
   this->status_.message = msg;
 }
@@ -299,16 +308,14 @@ void KeypadPairer::execute_(Request &req) {
     return;
   }
 
-  // The keypad model — and therefore the pairing dialect — comes solely from
-  // the live advertisement. If we can't identify it, we don't guess.
-  if (!ident.is_keypad) {
-    this->set_failed_("Could not identify the keypad from its advertisement. "
-                      "Reset it into pairing mode, keep it within 2 m and retry.");
-    return;
-  }
-  ESP_LOGI(TAG, "Pairing %s as %s family", ident.display_name,
-           ident.family == KeypadFamily::VISION ? "VISION" : "ORIGINAL");
-  const FamilyPreset &preset = preset_for(ident.family);
+  // The pairing dialect follows the family already identified by the UI (from
+  // the BLE service-data signature, cached by MAC). We do NOT re-derive it from
+  // this scan: the Keypad Vision doesn't carry its signature on every
+  // advertisement, so discover_target may legitimately fail to classify it even
+  // though it is a keypad. The scan above was only needed for the address type.
+  const KeypadFamily family = req.family;
+  ESP_LOGI(TAG, "Pairing keypad as %s family", keypad_family_str(family));
+  const FamilyPreset &preset = preset_for(family);
 
   // The keypad might currently be connected to our peripheral (server) role —
   // it sends IV requests to us as a SwitchBot Lock emulation. The BLE spec
@@ -450,10 +457,14 @@ void KeypadPairer::execute_(Request &req) {
   uint8_t finalize2[] = {0x0f, 0x53, 0x01, 0x06};
   this->send_command_(rx, finalize2, sizeof(finalize2));
 
-  // Enable the doorbell by default while we hold an authenticated session
-  // (Vision only). Best-effort: an unsupported keypad just ACKs and ignores it.
+  // Step 8 (Vision only): enable the doorbell while we still hold an
+  // authenticated session. The slot is written and finalised, so this is the
+  // last safe moment to push a setting before disconnecting. Surfaced as its
+  // own step — the user sees it happen instead of it being a silent extra.
+  // Still best-effort: the keypad is already paired and usable, so a missing
+  // ACK here must not fail the whole job.
   if (preset.enable_doorbell != nullptr) {
-    ESP_LOGI(TAG, "Enabling doorbell button");
+    this->set_step_(DOORBELL_STEP, STEP_LABELS[DOORBELL_STEP]);
     this->send_command_(rx, preset.enable_doorbell, preset.enable_doorbell_len);
   }
 
@@ -461,7 +472,7 @@ void KeypadPairer::execute_(Request &req) {
   client->disconnect();
   NimBLEDevice::deleteClient(client);
 
-  this->set_success_(req.keypad_mac, ident.family);
+  this->set_success_(req.keypad_mac, family);
 }
 
 }  // namespace switchbot_keypad_bridge

--- a/components/switchbot_keypad_bridge/keypad_pairer.h
+++ b/components/switchbot_keypad_bridge/keypad_pairer.h
@@ -71,6 +71,12 @@ class KeypadPairer {
   // untouched — only one pairing can be in flight at a time.
   std::string start(Request req);
 
+  // The user-facing label of each pairing step, in order. The wizard builds
+  // its progress stepper from these (returned by /api/pair), so the pairer
+  // is the single source of truth for step count, order and wording.
+  static uint8_t step_count();
+  static const char *step_label(uint8_t step);
+
   // Atomic snapshot of progress. Suitable for polling from any thread.
   Status status() const;
 

--- a/components/switchbot_keypad_bridge/keypad_pairer.h
+++ b/components/switchbot_keypad_bridge/keypad_pairer.h
@@ -35,7 +35,7 @@
 #include <string>
 #include <vector>
 
-#include "cloud_client.h"
+#include "keypad_advert.h"
 
 namespace esphome {
 namespace switchbot_keypad_bridge {
@@ -57,6 +57,10 @@ class KeypadPairer {
     std::string message;       // human-readable status of the current step
     std::string error;         // populated when state == FAILED
     std::string job_id;        // matches the value returned by start()
+    // Identity of the keypad just paired, valid only when state == SUCCESS.
+    // The family comes from the live advertisement read during discovery.
+    std::string keypad_mac;    // pretty form, e.g. "B0:E9:FE:..."
+    KeypadFamily family{KeypadFamily::ORIGINAL};
   };
 
   // Arguments for a single pairing attempt. The protocol family is NOT passed
@@ -84,7 +88,7 @@ class KeypadPairer {
   // Step helpers (push step number + message, log, return immediately).
   void set_step_(uint8_t step, const char *msg);
   void set_running_(uint8_t total, const std::string &job_id);
-  void set_success_();
+  void set_success_(const std::string &keypad_mac, KeypadFamily family);
   void set_failed_(const std::string &err);
 
   // BLE notification sink: we look for the 20-byte session-IV response

--- a/components/switchbot_keypad_bridge/keypad_pairer.h
+++ b/components/switchbot_keypad_bridge/keypad_pairer.h
@@ -14,15 +14,7 @@
 // Spawned once per pairing attempt; the HTTP handler polls `status()`
 // at ~2 Hz from the UI's `/api/pair/status`.
 
-#include <NimBLEDevice.h>
-
-// NimBLE leaks LOG_LEVEL_* macros that collide with ESPHome's enum.
-#undef LOG_LEVEL_NONE
-#undef LOG_LEVEL_ERROR
-#undef LOG_LEVEL_WARN
-#undef LOG_LEVEL_INFO
-#undef LOG_LEVEL_DEBUG
-#undef LOG_LEVEL_CRITICAL
+#include "nimble_compat.h"
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>

--- a/components/switchbot_keypad_bridge/keypad_pairer.h
+++ b/components/switchbot_keypad_bridge/keypad_pairer.h
@@ -55,11 +55,13 @@ class KeypadPairer {
     KeypadFamily family{KeypadFamily::ORIGINAL};
   };
 
-  // Arguments for a single pairing attempt. The protocol family is NOT passed
-  // in — the pairer reads it from the keypad's live BLE advertisement during
-  // discovery (keypad_advert.h), which is the single source of truth.
+  // Arguments for a single pairing attempt. `family` comes from the UI's
+  // advertisement-based identification (keypad_advert.h) and decides the step
+  // list shown; the pairer re-confirms it from the live advert during
+  // discovery and that live value drives the actual protocol dialect.
   struct Request {
     std::string                  keypad_mac;       // pretty form, e.g. "B0:E9:FE:..."
+    KeypadFamily                 family{KeypadFamily::ORIGINAL};
     int                          key_id{0};        // 0x88 / 0xC6 / ... from cloud
     std::vector<uint8_t>         key;              // 16-byte AES-CTR key from cloud
     std::array<uint8_t, 16>      shared_token{};   // the random key we inject
@@ -73,9 +75,10 @@ class KeypadPairer {
 
   // The user-facing label of each pairing step, in order. The wizard builds
   // its progress stepper from these (returned by /api/pair), so the pairer
-  // is the single source of truth for step count, order and wording.
-  static uint8_t step_count();
-  static const char *step_label(uint8_t step);
+  // is the single source of truth for step count, order and wording. The
+  // Vision family has one extra trailing step (enabling the doorbell).
+  static uint8_t step_count(KeypadFamily family);
+  static const char *step_label(KeypadFamily family, uint8_t step);
 
   // Atomic snapshot of progress. Suitable for polling from any thread.
   Status status() const;

--- a/components/switchbot_keypad_bridge/lock_protocol.cpp
+++ b/components/switchbot_keypad_bridge/lock_protocol.cpp
@@ -1,0 +1,80 @@
+#include "lock_protocol.h"
+
+#include <cstring>
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+namespace {
+
+// Plain-text command frames as decoded from the keypad. The state-poll
+// constant is a 3-byte prefix because the trailing byte is a per-family
+// model suffix (varies between keypad models).
+constexpr uint8_t FRAME_LOCK[8]              = {0x0F, 0x4E, 0x01, 0x03, 0x00, 0x00, 0x00, 0x00};
+constexpr uint8_t FRAME_ACTION[4]            = {0x0F, 0x4E, 0x01, 0x03};
+constexpr uint8_t FRAME_STATE_POLL_PREFIX[3] = {0x0F, 0x4F, 0x81};
+// Doorbell press (Keypad Vision). A short, distinct 2-byte opcode the keypad
+// sends on the shared slot when its doorbell button is pressed.
+constexpr uint8_t FRAME_DOORBELL[2]          = {0x01, 0x03};
+
+// Unlock frame layout: [hdr(4) | method | marker(0x80) | index | ...]
+constexpr size_t  UNLOCK_METHOD_OFFSET = 4;
+constexpr size_t  UNLOCK_MARKER_OFFSET = 5;
+constexpr size_t  UNLOCK_INDEX_OFFSET  = 6;
+constexpr uint8_t UNLOCK_MARKER        = 0x80;
+constexpr uint8_t UNLOCK_INDEX_BASE    = 0x0A;
+
+}  // namespace
+
+const char *unlock_method_name(UnlockMethod method) {
+  switch (method) {
+    case UnlockMethod::FINGERPRINT:
+      return "fingerprint";
+    case UnlockMethod::PIN:
+      return "pin";
+    case UnlockMethod::NFC:
+      return "nfc";
+    case UnlockMethod::FACE:
+      return "face";
+    default:
+      return "unknown";
+  }
+}
+
+DecodedCommand decode_lock_command(const uint8_t *plaintext, size_t length) {
+  DecodedCommand out;
+
+  if (length == sizeof(FRAME_LOCK) && std::memcmp(plaintext, FRAME_LOCK, sizeof(FRAME_LOCK)) == 0) {
+    out.type = CommandType::LOCK;
+    return out;
+  }
+  if (length == 4 &&
+      std::memcmp(plaintext, FRAME_STATE_POLL_PREFIX, sizeof(FRAME_STATE_POLL_PREFIX)) == 0) {
+    out.type = CommandType::STATE_POLL;
+    return out;
+  }
+  if (length == sizeof(FRAME_DOORBELL) &&
+      std::memcmp(plaintext, FRAME_DOORBELL, sizeof(FRAME_DOORBELL)) == 0) {
+    out.type = CommandType::DOORBELL;
+    return out;
+  }
+  if (length >= 8 && std::memcmp(plaintext, FRAME_ACTION, sizeof(FRAME_ACTION)) == 0 &&
+      plaintext[UNLOCK_MARKER_OFFSET] == UNLOCK_MARKER) {
+    out.type = CommandType::UNLOCK;
+    out.method = static_cast<UnlockMethod>(plaintext[UNLOCK_METHOD_OFFSET]);
+    const uint8_t idx_byte = plaintext[UNLOCK_INDEX_OFFSET];
+    // Original keypad: index encoded as 0x0A + zero-based slot. Vision: raw
+    // zero-based byte (we only have a single capture with 0x00, so this is
+    // a best-effort decode). Heuristic: if the byte ≥ 0x0A, treat as the
+    // original biased encoding; otherwise pass it through as the raw index.
+    out.credential_index = (idx_byte >= UNLOCK_INDEX_BASE)
+                               ? static_cast<int16_t>(idx_byte - UNLOCK_INDEX_BASE)
+                               : static_cast<int16_t>(idx_byte);
+    return out;
+  }
+
+  return out;  // type stays CommandType::UNKNOWN
+}
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/lock_protocol.h
+++ b/components/switchbot_keypad_bridge/lock_protocol.h
@@ -1,0 +1,49 @@
+#pragma once
+
+// SwitchBot keypad command decoding — the pure "what did the keypad ask for"
+// layer. It takes the already-decrypted plaintext bytes of a frame and
+// classifies them into a command, with no NimBLE, crypto or transport
+// dependencies. This is the half of the protocol worth reasoning about (and
+// testing) in isolation; the encrypted transport that feeds it lives in the
+// bridge component.
+
+#include <cstddef>
+#include <cstdint>
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+// How a credential presented itself at the keypad. Values are the method byte
+// the keypad sends inside an unlock frame.
+enum class UnlockMethod : uint8_t {
+  UNKNOWN = 0x00,
+  PIN = 0x04,
+  NFC = 0x08,
+  FINGERPRINT = 0x0C,
+  FACE = 0x18,
+};
+
+const char *unlock_method_name(UnlockMethod method);
+
+// The command a decrypted keypad frame represents. UNKNOWN means the bytes
+// matched no known frame — the caller should ACK and otherwise ignore it.
+enum class CommandType : uint8_t {
+  UNKNOWN,
+  LOCK,
+  UNLOCK,
+  STATE_POLL,
+  DOORBELL,
+};
+
+struct DecodedCommand {
+  CommandType type{CommandType::UNKNOWN};
+  UnlockMethod method{UnlockMethod::UNKNOWN};
+  int16_t credential_index{-1};
+};
+
+// Classify a decrypted plaintext frame. Returns a command with
+// type == CommandType::UNKNOWN when the bytes match no known frame.
+DecodedCommand decode_lock_command(const uint8_t *plaintext, size_t length);
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/lock_session.cpp
+++ b/components/switchbot_keypad_bridge/lock_session.cpp
@@ -1,0 +1,199 @@
+#include "lock_session.h"
+
+#include <cstring>
+
+#include <esp_random.h>
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "aes_ctr.h"
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+namespace {
+
+const char *const TAG = "switchbot_keypad_bridge.session";
+
+// Encrypted protocol framing.
+constexpr uint8_t PROTOCOL_MAGIC = 0x57;
+
+// Session IV negotiation: first frame received after connect.
+// Shape: 57 00 00 00 0F 21 03 <key_id>
+constexpr size_t SESSION_IV_REQ_MIN = 8;
+
+constexpr size_t AES_IV_SIZE = 16;
+constexpr size_t IV_RESPONSE_HEADER = 4;  // iv_response_ prefix before the IV bytes
+
+}  // namespace
+
+void LockSession::reset() {
+  this->iv_established_ = false;
+  this->clear_replay_history_();
+}
+
+LockSession::Action LockSession::process_frame(const std::string &frame) {
+  ESP_LOGV(TAG, "RX WIRE %zu bytes: %s", frame.size(),
+           format_hex_pretty(reinterpret_cast<const uint8_t *>(frame.data()), frame.size()).c_str());
+
+  if (this->is_iv_request_(frame)) {
+    // The IV request advertises which key_id the keypad will use for the
+    // rest of the session (`57 00 00 00 0F 21 03 <key_id>`). Adapt to it —
+    // Original/Touch uses 0x88, Vision/Vision Pro uses 0xC6.
+    const uint8_t requested_slot = static_cast<uint8_t>(frame[7]);
+    if (requested_slot != this->slot_id_) {
+      ESP_LOGI(TAG, "Token slot: 0x%02X", requested_slot);
+      this->slot_id_ = requested_slot;
+    }
+    ESP_LOGD(TAG, "IV request");
+    this->rotate_iv_();
+    // A new IV invalidates any ciphertext sniffed under the previous one.
+    this->clear_replay_history_();
+    this->iv_established_ = true;
+    return Action::SEND_IV;
+  }
+
+  if (frame.size() <= HEADER_LEN ||
+      static_cast<uint8_t>(frame[0]) != PROTOCOL_MAGIC) {
+    ESP_LOGD(TAG, "Ignoring non-protocol frame (size=%zu)", frame.size());
+    return Action::NONE;
+  }
+
+  this->header_ = FrameHeader{static_cast<uint8_t>(frame[1]), static_cast<uint8_t>(frame[2]),
+                              static_cast<uint8_t>(frame[3])};
+
+  if (this->header_.key_id != this->slot_id_) {
+    ESP_LOGD(TAG, "Ignoring frame with unexpected key_id=0x%02X", this->header_.key_id);
+    return Action::NONE;
+  }
+
+  // Refuse encrypted frames before the IV handshake completed in this session.
+  // A captured ciphertext from a previous connection would otherwise decrypt
+  // against the wrong (or stale) IV and ride on whatever lock state is set.
+  if (!this->iv_established_) {
+    ESP_LOGW(TAG, "Dropping encrypted frame: no IV negotiated in this session");
+    return Action::NONE;
+  }
+
+  // The protocol echoes IV[0..1] back as the seq_a/seq_b header bytes.
+  // Reject anything that does not match the IV we just issued — this blocks
+  // cross-session replay of captured ciphertexts.
+  if (this->header_.seq_a != this->iv_response_[IV_RESPONSE_HEADER] ||
+      this->header_.seq_b != this->iv_response_[IV_RESPONSE_HEADER + 1]) {
+    ESP_LOGW(TAG, "Dropping frame: seq_a/seq_b mismatch (cross-session replay?)");
+    return Action::NONE;
+  }
+
+  const size_t ct_len = frame.size() - HEADER_LEN;
+  if (ct_len > MAX_PAYLOAD) {
+    ESP_LOGW(TAG, "Dropping frame with invalid payload length: %zu", ct_len);
+    return Action::NONE;
+  }
+
+  const uint8_t *ciphertext = reinterpret_cast<const uint8_t *>(frame.data() + HEADER_LEN);
+
+  // Intra-session replay protection for state-changing actions: under a
+  // fixed session IV, identical plaintexts produce identical ciphertexts.
+  // We only flag duplicates that decode to a side-effecting command — state
+  // polls are idempotent and a legitimate keypad emits them repeatedly.
+  const bool ciphertext_seen = this->is_replayed_ciphertext_(ciphertext, ct_len);
+
+  uint8_t plaintext[MAX_PAYLOAD];
+  if (!this->xcrypt_(ciphertext, ct_len, plaintext)) {
+    return Action::NONE;  // error already logged
+  }
+
+  ESP_LOGD(TAG, "RX %s", format_hex_pretty(plaintext, ct_len).c_str());
+
+  this->command_ = decode_lock_command(plaintext, ct_len);
+  if (this->command_.type == CommandType::UNKNOWN) {
+    ESP_LOGI(TAG, "Unhandled command: %s", format_hex_pretty(plaintext, ct_len).c_str());
+    return Action::COMMAND;  // the bridge still ACKs unknown frames
+  }
+
+  // DOORBELL is deliberately left out of the replay filter: under a fixed
+  // session IV a second legitimate press in the same connection produces the
+  // exact same ciphertext, and dropping it would swallow real rings. Worst
+  // case for a replayed doorbell frame is a spurious chime; a replayed
+  // lock/unlock changes security state, so only those are filtered.
+  if (this->command_.type == CommandType::LOCK || this->command_.type == CommandType::UNLOCK) {
+    if (ciphertext_seen) {
+      ESP_LOGW(TAG, "Dropping action: ciphertext replay within session");
+      return Action::NONE;
+    }
+    this->record_ciphertext_(ciphertext, ct_len);
+  }
+
+  return Action::COMMAND;
+}
+
+bool LockSession::is_iv_request_(const std::string &frame) const {
+  return frame.size() >= SESSION_IV_REQ_MIN &&
+         static_cast<uint8_t>(frame[0]) == PROTOCOL_MAGIC &&
+         static_cast<uint8_t>(frame[1]) == 0x00 &&
+         static_cast<uint8_t>(frame[5]) == 0x21 &&
+         static_cast<uint8_t>(frame[6]) == 0x03;
+}
+
+size_t LockSession::encrypt_response(const FrameHeader &header, const uint8_t *plaintext,
+                                     size_t length, uint8_t out[MAX_PACKET]) {
+  if (length > MAX_PAYLOAD) {
+    ESP_LOGE(TAG, "Response payload too large (%zu > %zu)", length, MAX_PAYLOAD);
+    return 0;
+  }
+  out[0] = 0x01;
+  out[1] = header.key_id;
+  out[2] = header.seq_a;
+  out[3] = header.seq_b;
+  if (!this->xcrypt_(plaintext, length, out + HEADER_LEN)) {
+    return 0;
+  }
+  return HEADER_LEN + length;
+}
+
+bool LockSession::xcrypt_(const uint8_t *input, size_t length, uint8_t *output) {
+  return aes_ctr_xcrypt(this->aes_key_,
+                        this->iv_response_.data() + IV_RESPONSE_HEADER,
+                        input, output, length);
+}
+
+void LockSession::rotate_iv_() {
+  for (size_t i = 0; i < AES_IV_SIZE; i += 4) {
+    const uint32_t value = esp_random();
+    std::memcpy(this->iv_response_.data() + IV_RESPONSE_HEADER + i, &value, 4);
+  }
+  ESP_LOGV(TAG, "IV rotated: %s",
+           format_hex_pretty(this->iv_response_.data() + IV_RESPONSE_HEADER, AES_IV_SIZE).c_str());
+}
+
+void LockSession::clear_replay_history_() {
+  this->replay_head_ = 0;
+  for (auto &entry : this->replay_history_) {
+    entry.length = 0;
+  }
+}
+
+bool LockSession::is_replayed_ciphertext_(const uint8_t *ciphertext, size_t length) const {
+  if (length == 0 || length > MAX_PAYLOAD) {
+    return false;
+  }
+  for (const auto &entry : this->replay_history_) {
+    if (entry.length == length && std::memcmp(entry.data.data(), ciphertext, length) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void LockSession::record_ciphertext_(const uint8_t *ciphertext, size_t length) {
+  if (length == 0 || length > MAX_PAYLOAD) {
+    return;
+  }
+  ReplayEntry &slot = this->replay_history_[this->replay_head_];
+  std::memcpy(slot.data.data(), ciphertext, length);
+  slot.length = length;
+  this->replay_head_ = (this->replay_head_ + 1) % REPLAY_HISTORY_SIZE;
+}
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/lock_session.h
+++ b/components/switchbot_keypad_bridge/lock_session.h
@@ -1,0 +1,113 @@
+#pragma once
+
+// Encrypted-session state machine for the emulated SwitchBot Lock: token-slot
+// learning, IV negotiation, frame validation, AES-CTR transport crypto and
+// anti-replay. Bytes in, decoded commands out — no NimBLE and no ESPHome
+// entities, so the entire validation pipeline lives in one reviewable place.
+// The bridge owns the transport (BLE notify) and the business logic (lock
+// state, entity publishing) on top of it.
+
+#include <psa/crypto.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "lock_protocol.h"
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+// 4-byte transport header echoed back on every encrypted exchange.
+struct FrameHeader {
+  uint8_t key_id;
+  uint8_t seq_a;
+  uint8_t seq_b;
+};
+
+class LockSession {
+ public:
+  static constexpr size_t HEADER_LEN = 4;   // [0x57|0x01, key_id, seq_a, seq_b]
+  static constexpr size_t MAX_PAYLOAD = 32;
+  static constexpr size_t MAX_PACKET = HEADER_LEN + MAX_PAYLOAD;
+
+  // Outcome of feeding one received frame into the session.
+  enum class Action : uint8_t {
+    NONE,     // frame dropped — the reason has been logged
+    SEND_IV,  // IV request handled: notify iv_response()
+    COMMAND,  // decrypted and decoded: header() / command() are valid
+  };
+
+  // (Re-)point the session at an imported PSA AES-CTR key. The bridge owns
+  // key generation, NVS persistence and PSA import (including the unpair
+  // rotation); the session only uses the handle.
+  void set_aes_key(psa_key_id_t key) { this->aes_key_ = key; }
+
+  // Drop all per-connection state: IV, replay history. Called on connect,
+  // disconnect and unpair. The learned token slot survives — once adopted
+  // from an IV request it is a property of the paired keypad, not of one
+  // connection.
+  void reset();
+
+  // Forget the learned token slot as well (unpair only).
+  void forget_slot() { this->slot_id_ = 0x00; }
+
+  // Validate, decrypt and decode one received frame. On COMMAND the decoded
+  // result is available via header()/command() until the next call.
+  Action process_frame(const std::string &frame);
+
+  // Valid after process_frame() returned COMMAND.
+  const FrameHeader &header() const { return this->header_; }
+  const DecodedCommand &command() const { return this->command_; }
+
+  // The 20-byte session-IV response to notify after SEND_IV:
+  // [0x01, 0x00, 0x00, 0x00, IV(16)]. The trailing 16 bytes double as the
+  // AES-CTR IV of the live session.
+  const uint8_t *iv_response() const { return this->iv_response_.data(); }
+  size_t iv_response_size() const { return this->iv_response_.size(); }
+
+  // Encrypt `plaintext` into a notify-ready packet
+  // [0x01, key_id, seq_a, seq_b, ciphertext…] written to `out` (which must
+  // hold MAX_PACKET bytes). Returns the packet length, 0 on failure (logged).
+  size_t encrypt_response(const FrameHeader &header, const uint8_t *plaintext,
+                          size_t length, uint8_t out[MAX_PACKET]);
+
+ private:
+  bool is_iv_request_(const std::string &frame) const;
+  void rotate_iv_();
+
+  // AES-CTR is symmetric, so a single primitive covers both directions.
+  bool xcrypt_(const uint8_t *input, size_t length, uint8_t *output);
+
+  void clear_replay_history_();
+  bool is_replayed_ciphertext_(const uint8_t *ciphertext, size_t length) const;
+  void record_ciphertext_(const uint8_t *ciphertext, size_t length);
+
+  psa_key_id_t aes_key_{PSA_KEY_ID_NULL};
+
+  // Token-slot key_id the keypad uses post-pairing. Auto-learned from the
+  // IV-request frame the keypad sends as the first message of every session
+  // (Original/Touch=0x88, Vision/Vision Pro=0xC6, …). 0x00 = not yet seen;
+  // no encrypted frame is accepted until the IV handshake has set it.
+  uint8_t slot_id_{0x00};
+
+  std::array<uint8_t, 20> iv_response_{0x01, 0x00, 0x00, 0x00};
+  bool iv_established_{false};
+
+  // Per-session anti-replay state. Reset on connect, disconnect, and on
+  // every IV re-negotiation.
+  static constexpr size_t REPLAY_HISTORY_SIZE = 8;
+  struct ReplayEntry {
+    std::array<uint8_t, MAX_PAYLOAD> data{};
+    size_t length{0};
+  };
+  std::array<ReplayEntry, REPLAY_HISTORY_SIZE> replay_history_{};
+  size_t replay_head_{0};
+
+  FrameHeader header_{};
+  DecodedCommand command_{};
+};
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/mac_utils.cpp
+++ b/components/switchbot_keypad_bridge/mac_utils.cpp
@@ -1,0 +1,51 @@
+#include "mac_utils.h"
+
+#include <cctype>
+#include <cstdio>
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+std::string compact_mac(const std::string &any) {
+  std::string out;
+  out.reserve(12);
+  for (char c : any) {
+    if (c == ':' || c == '-')
+      continue;
+    out.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+  }
+  return out;
+}
+
+std::string pretty_mac(const std::string &raw) {
+  const std::string compact = compact_mac(raw);
+  if (compact.size() != 12) return raw;
+  std::string out;
+  out.reserve(17);
+  for (size_t i = 0; i < 12; i += 2) {
+    if (!out.empty()) out.push_back(':');
+    out.push_back(compact[i]);
+    out.push_back(compact[i + 1]);
+  }
+  return out;
+}
+
+std::string upper_mac(std::string mac) {
+  for (auto &c : mac) {
+    if (c >= 'a' && c <= 'z') c = static_cast<char>(c - 'a' + 'A');
+  }
+  return mac;
+}
+
+bool parse_mac_pretty(const std::string &mac, uint8_t out[6]) {
+  unsigned b[6];
+  if (std::sscanf(mac.c_str(), "%2x:%2x:%2x:%2x:%2x:%2x",
+                  &b[0], &b[1], &b[2], &b[3], &b[4], &b[5]) != 6) {
+    return false;
+  }
+  for (size_t i = 0; i < 6; ++i) out[i] = static_cast<uint8_t>(b[i]);
+  return true;
+}
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/mac_utils.h
+++ b/components/switchbot_keypad_bridge/mac_utils.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// MAC-address string/byte conversions shared by the cloud client, the
+// pairer, the pairing UI and the bridge. Pure string handling — no NimBLE
+// or ESP-IDF dependency.
+
+#include <cstdint>
+#include <string>
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+// Convert "B0E9FE612E75" → "B0:E9:FE:61:2E:75". Idempotent on already-
+// pretty input. Defensive on malformed input (returned as-is).
+std::string pretty_mac(const std::string &raw);
+
+// Any separators / case → "B0E9FE612E75".
+std::string compact_mac(const std::string &any);
+
+// Upper-cased copy of a MAC string, for case-insensitive comparisons
+// ("b0:e9:fe:…" → "B0:E9:FE:…").
+std::string upper_mac(std::string mac);
+
+// Parse "B0:E9:FE:11:22:33" (any case) into 6 big-endian bytes.
+bool parse_mac_pretty(const std::string &mac, uint8_t out[6]);
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/nimble_compat.h
+++ b/components/switchbot_keypad_bridge/nimble_compat.h
@@ -1,0 +1,18 @@
+#pragma once
+
+// The component's single include point for NimBLE.
+//
+// NimBLE's log_common.h defines LOG_LEVEL_* as plain macros, which collide
+// with identically-named members of ESPHome enums included downstream.
+// ESPHome uses ESPHOME_LOG_LEVEL_* for its own logging, so undefining the
+// macros right after the NimBLE headers is safe. Include this instead of
+// <NimBLEDevice.h> so no header can forget the cleanup.
+
+#include <NimBLEDevice.h>
+
+#undef LOG_LEVEL_NONE
+#undef LOG_LEVEL_ERROR
+#undef LOG_LEVEL_WARN
+#undef LOG_LEVEL_INFO
+#undef LOG_LEVEL_DEBUG
+#undef LOG_LEVEL_CRITICAL

--- a/components/switchbot_keypad_bridge/pairing_ui.cpp
+++ b/components/switchbot_keypad_bridge/pairing_ui.cpp
@@ -341,13 +341,18 @@ std::string PairingUi::read_body_(httpd_req_t *req) {
   if (req->content_len == 0 || req->content_len > MAX_BODY_LEN) {
     return buf;
   }
+  // httpd_req_recv may legitimately return less than content_len (the body
+  // can arrive split across TCP segments), so keep reading until complete.
   buf.resize(req->content_len);
-  int received = httpd_req_recv(req, buf.data(),
-                                static_cast<int>(req->content_len));
-  if (received <= 0) {
-    buf.clear();
-  } else {
-    buf.resize(received);
+  size_t received = 0;
+  while (received < req->content_len) {
+    int r = httpd_req_recv(req, buf.data() + received,
+                           static_cast<int>(req->content_len - received));
+    if (r <= 0) {
+      buf.clear();
+      return buf;
+    }
+    received += static_cast<size_t>(r);
   }
   return buf;
 }

--- a/components/switchbot_keypad_bridge/pairing_ui.cpp
+++ b/components/switchbot_keypad_bridge/pairing_ui.cpp
@@ -286,6 +286,12 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   self->success_notified_    = false;
   cJSON *resp = cJSON_CreateObject();
   cJSON_AddStringToObject(resp, "job_id", job_id.c_str());
+  // Step labels for the progress stepper — the wizard renders these, so the
+  // pairer stays the single source of truth for count, order and wording.
+  cJSON *labels = cJSON_AddArrayToObject(resp, "labels");
+  for (uint8_t i = 0; i < KeypadPairer::step_count(); ++i) {
+    cJSON_AddItemToArray(labels, cJSON_CreateString(KeypadPairer::step_label(i)));
+  }
   return reply_json_(req, json_take(resp).c_str());
 }
 

--- a/components/switchbot_keypad_bridge/pairing_ui.cpp
+++ b/components/switchbot_keypad_bridge/pairing_ui.cpp
@@ -10,6 +10,7 @@
 #include "esphome/core/log.h"
 #include "ble_utils.h"
 #include "keypad_advert.h"
+#include "mac_utils.h"
 
 namespace esphome {
 namespace switchbot_keypad_bridge {

--- a/components/switchbot_keypad_bridge/pairing_ui.cpp
+++ b/components/switchbot_keypad_bridge/pairing_ui.cpp
@@ -1,11 +1,14 @@
 #include "pairing_ui.h"
 
-#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <map>
 #include <vector>
 
+#include <cJSON.h>
+
 #include "esphome/core/log.h"
+#include "ble_utils.h"
 #include "keypad_advert.h"
 
 namespace esphome {
@@ -83,58 +86,33 @@ esp_err_t PairingUi::handle_root_(httpd_req_t *req) {
 
 namespace {
 
-// Minimal escaper for the JSON strings we emit. Handles the cases we
-// realistically see (quotes and backslashes inside device names).
-std::string json_escape(const std::string &s) {
-  std::string out;
-  out.reserve(s.size() + 8);
-  for (char c : s) {
-    switch (c) {
-      case '"':  out += "\\\""; break;
-      case '\\': out += "\\\\"; break;
-      case '\n': out += "\\n"; break;
-      case '\r': out += "\\r"; break;
-      case '\t': out += "\\t"; break;
-      default:
-        if (static_cast<unsigned char>(c) < 0x20) {
-          char buf[8];
-          std::snprintf(buf, sizeof(buf), "\\u%04x", c);
-          out += buf;
-        } else {
-          out.push_back(c);
-        }
+// Serialize a cJSON node to a compact string, then free the node. cJSON owns
+// the escaping, so callers never hand-build JSON. Returns `fallback` if
+// allocation fails (only under OOM).
+std::string json_take(cJSON *node, const char *fallback = "{}") {
+  std::string out = fallback;
+  if (node != nullptr) {
+    char *s = cJSON_PrintUnformatted(node);
+    if (s != nullptr) {
+      out = s;
+      cJSON_free(s);
     }
+    cJSON_Delete(node);
   }
   return out;
 }
 
-// Pull a top-level JSON string property out of a request body. Returns
-// empty on missing/malformed. Tiny hand-rolled extractor — we only need
-// it for two fields and don't want to pull cJSON into the request path.
+// Pull a top-level JSON string property out of a request body. Returns empty
+// when the body isn't valid JSON or the field is absent / not a string.
 std::string extract_json_str(const std::string &body, const char *key) {
-  std::string needle = std::string("\"") + key + "\"";
-  size_t k = body.find(needle);
-  if (k == std::string::npos) return "";
-  size_t colon = body.find(':', k);
-  if (colon == std::string::npos) return "";
-  size_t open = body.find('"', colon);
-  if (open == std::string::npos) return "";
-  ++open;
+  cJSON *root = cJSON_ParseWithLength(body.data(), body.size());
+  if (root == nullptr) return "";
   std::string out;
-  while (open < body.size() && body[open] != '"') {
-    if (body[open] == '\\' && open + 1 < body.size()) {
-      char esc = body[open + 1];
-      switch (esc) {
-        case 'n': out.push_back('\n'); break;
-        case 'r': out.push_back('\r'); break;
-        case 't': out.push_back('\t'); break;
-        default:  out.push_back(esc);
-      }
-      open += 2;
-    } else {
-      out.push_back(body[open++]);
-    }
+  cJSON *item = cJSON_GetObjectItemCaseSensitive(root, key);
+  if (cJSON_IsString(item) && item->valuestring != nullptr) {
+    out = item->valuestring;
   }
+  cJSON_Delete(root);
   return out;
 }
 
@@ -145,16 +123,6 @@ struct NearbyDevice {
   std::vector<uint8_t> svc_data;
 };
 
-// Read the SwitchBot service-data blob from an advertisement (UUID 0xFD3D,
-// with the legacy 0x0D00 as a fallback). Empty when not present.
-std::vector<uint8_t> switchbot_service_data(const NimBLEAdvertisedDevice *adv) {
-  static const NimBLEUUID U_FD3D(static_cast<uint16_t>(0xFD3D));
-  static const NimBLEUUID U_0D00(static_cast<uint16_t>(0x0D00));
-  std::string sd = adv->getServiceData(U_FD3D);
-  if (sd.empty()) sd = adv->getServiceData(U_0D00);
-  return std::vector<uint8_t>(sd.begin(), sd.end());
-}
-
 // Active-scan for `duration_ms` and record, for each advertising address
 // (upper-case, colon-separated), the strongest RSSI and its SwitchBot service
 // data. Lets the UI flag which account keypads are reachable right now and
@@ -162,18 +130,12 @@ std::vector<uint8_t> switchbot_service_data(const NimBLEAdvertisedDevice *adv) {
 std::map<std::string, NearbyDevice> scan_nearby(uint32_t duration_ms) {
   std::map<std::string, NearbyDevice> seen;
   NimBLEScan *scan = NimBLEDevice::getScan();
-  scan->clearResults();
-  scan->setActiveScan(true);
-  scan->setInterval(45);
-  scan->setWindow(30);
+  configure_switchbot_scan(scan);
 
   NimBLEScanResults results = scan->getResults(duration_ms, false);
   for (int i = 0; i < results.getCount(); ++i) {
     const NimBLEAdvertisedDevice *adv = results.getDevice(i);
-    std::string mac = adv->getAddress().toString();
-    for (auto &c : mac) {
-      if (c >= 'a' && c <= 'z') c = static_cast<char>(c - 'a' + 'A');
-    }
+    const std::string mac = upper_mac(adv->getAddress().toString());
     const int rssi = adv->getRSSI();
     auto it = seen.find(mac);
     if (it == seen.end() || rssi > it->second.rssi) {
@@ -204,10 +166,9 @@ esp_err_t PairingUi::handle_login_(httpd_req_t *req) {
     ESP_LOGW(TAG, "Login failed: %s", err.c_str());
     return reply_error_(req, "401 Unauthorized", err);
   }
-  std::string resp = R"json({"region":")json";
-  resp += json_escape(self->cloud_.region());
-  resp += R"json("})json";
-  return reply_json_(req, resp.c_str());
+  cJSON *resp = cJSON_CreateObject();
+  cJSON_AddStringToObject(resp, "region", self->cloud_.region().c_str());
+  return reply_json_(req, json_take(resp).c_str());
 }
 
 esp_err_t PairingUi::handle_keypads_(httpd_req_t *req) {
@@ -215,10 +176,10 @@ esp_err_t PairingUi::handle_keypads_(httpd_req_t *req) {
   if (!self->cloud_.is_logged_in()) {
     return reply_error_(req, "401 Unauthorized", "Sign in first.");
   }
-  std::vector<CloudClient::AccountKeypad> keypads;
+  std::vector<CloudClient::AccountDevice> devices;
   std::string err;
-  if (!self->cloud_.list_keypads(keypads, err)) {
-    ESP_LOGW(TAG, "list_keypads failed: %s", err.c_str());
+  if (!self->cloud_.list_devices(devices, err)) {
+    ESP_LOGW(TAG, "list_devices failed: %s", err.c_str());
     return reply_error_(req, "502 Bad Gateway", err);
   }
 
@@ -227,9 +188,9 @@ esp_err_t PairingUi::handle_keypads_(httpd_req_t *req) {
   // the keypad model straight from the advertisement (pySwitchbot-style).
   const std::map<std::string, NearbyDevice> nearby = scan_nearby(4000);
 
-  std::string out = "[";
+  cJSON *arr = cJSON_CreateArray();
   unsigned shown = 0;
-  for (const auto &k : keypads) {
+  for (const auto &k : devices) {
     const auto hit = nearby.find(k.mac_pretty);
     if (hit == nearby.end() || hit->second.svc_data.empty()) continue;
 
@@ -240,39 +201,20 @@ esp_err_t PairingUi::handle_keypads_(httpd_req_t *req) {
                                               hit->second.svc_data.size());
     if (!ident.is_keypad) continue;
 
-    if (shown++ != 0) out += ",";
-    out += R"json({"mac":")json";
-    out += json_escape(k.mac_pretty);
-    out += R"json(","name":")json";
-    out += json_escape(k.name);
-    out += R"json(","model":")json";
-    out += json_escape(ident.display_name);
-    out += R"json(","online":true,"rssi":)json";
-    out += std::to_string(hit->second.rssi);
-    out += "}";
+    cJSON *o = cJSON_CreateObject();
+    cJSON_AddStringToObject(o, "mac", k.mac_pretty.c_str());
+    cJSON_AddStringToObject(o, "name", k.name.c_str());
+    cJSON_AddStringToObject(o, "model", ident.display_name);
+    cJSON_AddBoolToObject(o, "online", true);
+    cJSON_AddNumberToObject(o, "rssi", hit->second.rssi);
+    cJSON_AddItemToArray(arr, o);
+    ++shown;
   }
-  out += "]";
   ESP_LOGI(TAG, "GET /api/keypads -> %u keypad(s) of %u account device(s), %u nearby",
-           shown, static_cast<unsigned>(keypads.size()),
+           shown, static_cast<unsigned>(devices.size()),
            static_cast<unsigned>(nearby.size()));
-  return reply_json_(req, out.c_str());
+  return reply_json_(req, json_take(arr, "[]").c_str());
 }
-
-namespace {
-
-// Read the ESP's BLE peripheral address as a 6-byte big-endian array
-// (MAC[0] is the leading byte). NimBLEAddress stores the bytes in
-// little-endian internally so we reverse on the way out.
-std::array<uint8_t, 6> esp_ble_mac() {
-  std::array<uint8_t, 6> out{};
-  const uint8_t *raw = NimBLEDevice::getAddress().getBase()->val;
-  for (size_t i = 0; i < 6; ++i) {
-    out[i] = raw[5 - i];
-  }
-  return out;
-}
-
-}  // namespace
 
 esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   auto *self = static_cast<PairingUi *>(req->user_ctx);
@@ -290,15 +232,15 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   // Confirm the MAC belongs to this account (and grab its pretty form + name).
   // The protocol family is determined later by the pairer from the keypad's
   // live BLE advertisement.
-  std::vector<CloudClient::AccountKeypad> keypads;
+  std::vector<CloudClient::AccountDevice> devices;
   std::string err;
-  if (!self->cloud_.list_keypads(keypads, err)) {
+  if (!self->cloud_.list_devices(devices, err)) {
     return reply_error_(req, "502 Bad Gateway", err);
   }
-  const CloudClient::AccountKeypad *found = nullptr;
-  for (const auto &kp : keypads) {
-    if (kp.mac_pretty == mac || kp.mac == mac) {
-      found = &kp;
+  const CloudClient::AccountDevice *found = nullptr;
+  for (const auto &dev : devices) {
+    if (dev.mac_pretty == mac || dev.mac == mac) {
+      found = &dev;
       break;
     }
   }
@@ -322,7 +264,7 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   kr.key_id     = static_cast<int>(std::strtol(key_id_hex.c_str(), nullptr, 16));
   kr.key        = std::move(key_bytes);
   kr.shared_token = self->shared_key_;
-  kr.esp_mac = esp_ble_mac();
+  kr.esp_mac = addr_bytes(NimBLEDevice::getAddress());
 
   // Capture the name now — it belongs to this exact job.
   const std::string keypad_name = found->name;
@@ -338,10 +280,9 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   self->pairing_keypad_name_ = keypad_name;
   self->pairing_job_id_      = job_id;
   self->success_notified_    = false;
-  std::string resp = R"json({"job_id":")json";
-  resp += job_id;
-  resp += R"json("})json";
-  return reply_json_(req, resp.c_str());
+  cJSON *resp = cJSON_CreateObject();
+  cJSON_AddStringToObject(resp, "job_id", job_id.c_str());
+  return reply_json_(req, json_take(resp).c_str());
 }
 
 esp_err_t PairingUi::handle_pair_status_(httpd_req_t *req) {
@@ -354,31 +295,25 @@ esp_err_t PairingUi::handle_pair_status_(httpd_req_t *req) {
   if (st.state == KeypadPairer::State::SUCCESS && !self->success_notified_ &&
       st.job_id == self->pairing_job_id_ && !self->pairing_job_id_.empty()) {
     self->success_notified_ = true;
-    if (self->on_paired_cb_) self->on_paired_cb_(self->pairing_keypad_name_);
+    if (self->on_paired_cb_) {
+      self->on_paired_cb_(self->pairing_keypad_name_, st.keypad_mac, st.family);
+    }
   }
 
-  bool done = st.state == KeypadPairer::State::SUCCESS ||
-              st.state == KeypadPairer::State::FAILED;
+  const bool done = st.state == KeypadPairer::State::SUCCESS ||
+                    st.state == KeypadPairer::State::FAILED;
 
-  std::string resp = "{";
-  resp += R"json("step":)json";
-  resp += std::to_string(st.step);
-  resp += R"json(,"total":)json";
-  resp += std::to_string(st.total);
-  resp += R"json(,"message":")json";
-  resp += json_escape(st.message);
-  resp += R"json(","done":)json";
-  resp += done ? "true" : "false";
-  resp += R"json(,"error":)json";
+  cJSON *resp = cJSON_CreateObject();
+  cJSON_AddNumberToObject(resp, "step", st.step);
+  cJSON_AddNumberToObject(resp, "total", st.total);
+  cJSON_AddStringToObject(resp, "message", st.message.c_str());
+  cJSON_AddBoolToObject(resp, "done", done);
   if (st.state == KeypadPairer::State::FAILED) {
-    resp += R"json(")json";
-    resp += json_escape(st.error);
-    resp += R"json(")json";
+    cJSON_AddStringToObject(resp, "error", st.error.c_str());
   } else {
-    resp += "null";
+    cJSON_AddNullToObject(resp, "error");
   }
-  resp += "}";
-  return reply_json_(req, resp.c_str());
+  return reply_json_(req, json_take(resp).c_str());
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────
@@ -393,18 +328,9 @@ esp_err_t PairingUi::reply_json_(httpd_req_t *req, const char *json,
 
 esp_err_t PairingUi::reply_error_(httpd_req_t *req, const char *status,
                                   const std::string &message) {
-  std::string body = R"json({"error":")json";
-  for (char c : message) {
-    if (c == '"' || c == '\\') body.push_back('\\');
-    if (c == '\n' || c == '\r' || c == '\t') {
-      body += "\\";
-      body.push_back(c == '\n' ? 'n' : (c == '\r' ? 'r' : 't'));
-    } else {
-      body.push_back(c);
-    }
-  }
-  body += R"json("})json";
-  return reply_json_(req, body.c_str(), status);
+  cJSON *body = cJSON_CreateObject();
+  cJSON_AddStringToObject(body, "error", message.c_str());
+  return reply_json_(req, json_take(body).c_str(), status);
 }
 
 std::string PairingUi::read_body_(httpd_req_t *req) {

--- a/components/switchbot_keypad_bridge/pairing_ui.cpp
+++ b/components/switchbot_keypad_bridge/pairing_ui.cpp
@@ -81,6 +81,9 @@ esp_err_t PairingUi::handle_root_(httpd_req_t *req) {
   }
   httpd_resp_set_type(req, "text/html; charset=utf-8");
   httpd_resp_set_hdr(req, "Cache-Control", "no-store");
+  // The page is stored gzip-compressed in flash (see __init__.py). Served
+  // as-is without checking Accept-Encoding: every browser accepts gzip.
+  httpd_resp_set_hdr(req, "Content-Encoding", "gzip");
   return httpd_resp_send(req, reinterpret_cast<const char *>(self->html_),
                          static_cast<ssize_t>(self->html_len_));
 }

--- a/components/switchbot_keypad_bridge/pairing_ui.cpp
+++ b/components/switchbot_keypad_bridge/pairing_ui.cpp
@@ -121,9 +121,10 @@ std::string extract_json_str(const std::string &body, const char *key) {
 }
 
 // One nearby BLE device: strongest RSSI seen plus its SwitchBot service-data
-// blob (so the UI can identify the keypad model the pySwitchbot way).
+// blob (so the UI can identify the keypad model the pySwitchbot way). rssi
+// starts below any real BLE reading so the first packet always wins.
 struct NearbyDevice {
-  int rssi{0};
+  int rssi{-128};
   std::vector<uint8_t> svc_data;
 };
 
@@ -141,13 +142,17 @@ std::map<std::string, NearbyDevice> scan_nearby(uint32_t duration_ms) {
     const NimBLEAdvertisedDevice *adv = results.getDevice(i);
     const std::string mac = upper_mac(adv->getAddress().toString());
     const int rssi = adv->getRSSI();
-    auto it = seen.find(mac);
-    if (it == seen.end() || rssi > it->second.rssi) {
-      NearbyDevice &dev = seen[mac];
-      dev.rssi = rssi;
-      std::vector<uint8_t> sd = switchbot_service_data(adv);
-      if (!sd.empty()) dev.svc_data = std::move(sd);
-    }
+    NearbyDevice &dev = seen[mac];  // inserts a default entry on first sight
+    if (rssi > dev.rssi) dev.rssi = rssi;
+    // The 0xFD3D service data rides in the scan response, which usually arrives
+    // as a separate packet at a different RSSI than the plain advertisement.
+    // Capture it whenever a packet carries it — independent of RSSI. Gating this
+    // on "strongest RSSI seen" (as before) dropped a keypad's service data
+    // whenever its adv packet was stronger than its scan response, leaving the
+    // device looking like a non-keypad. With two keypads in range that flakily
+    // hid one or the other depending on packet order.
+    std::vector<uint8_t> sd = switchbot_service_data(adv);
+    if (!sd.empty()) dev.svc_data = std::move(sd);
   }
   scan->clearResults();
   return seen;
@@ -190,25 +195,44 @@ esp_err_t PairingUi::handle_keypads_(httpd_req_t *req) {
   // Cross-reference the account devices against a fresh BLE scan: this both
   // shows which ones are in range (and how strong the signal is) and identifies
   // the keypad model straight from the advertisement (pySwitchbot-style).
-  const std::map<std::string, NearbyDevice> nearby = scan_nearby(4000);
+  // 8 s: keypads are battery devices that advertise infrequently when idle, and
+  // the radio is time-shared with WiFi and the lock advertising — a short window
+  // often catches only one of several keypads. A longer scan reliably finds all.
+  const std::map<std::string, NearbyDevice> nearby = scan_nearby(8000);
 
   cJSON *arr = cJSON_CreateArray();
   unsigned shown = 0;
   for (const auto &k : devices) {
     const auto hit = nearby.find(k.mac_pretty);
-    if (hit == nearby.end() || hit->second.svc_data.empty()) continue;
+    if (hit == nearby.end()) continue;  // not in BLE range right now
 
-    // A device is a keypad only if its live advertisement matches a known
-    // SwitchBot keypad signature. Everything else (locks, bots, hubs, …) and
-    // any out-of-range device is skipped — detection is BLE-only.
-    const KeypadIdent ident = identify_keypad(hit->second.svc_data.data(),
-                                              hit->second.svc_data.size());
+    // Identify from the live advertisement. A keypad's signature rides in the
+    // 0xFD3D service data, which for the Keypad Vision only arrives in the
+    // (intermittently received) scan response. So cache every positive
+    // identification by MAC and fall back to it on later scans where the
+    // service data was missed — as long as the device is still in range. This
+    // is what keeps the Vision from flickering in and out of the list.
+    KeypadIdent ident =
+        identify_keypad(hit->second.svc_data.data(), hit->second.svc_data.size());
+    if (ident.is_keypad) {
+      self->identified_keypads_[k.mac_pretty] = ident;
+    } else {
+      const auto cached = self->identified_keypads_.find(k.mac_pretty);
+      if (cached != self->identified_keypads_.end()) ident = cached->second;
+    }
     if (!ident.is_keypad) continue;
+
+    ESP_LOGI(TAG, "keypad '%s' %s family=%s rssi=%d", k.name.c_str(),
+             k.mac_pretty.c_str(), keypad_family_str(ident.family),
+             hit->second.rssi);
 
     cJSON *o = cJSON_CreateObject();
     cJSON_AddStringToObject(o, "mac", k.mac_pretty.c_str());
     cJSON_AddStringToObject(o, "name", k.name.c_str());
-    cJSON_AddStringToObject(o, "model", ident.display_name);
+    // The pairing dialect (and which steps the wizard shows) follows from the
+    // family detected here. The browser echoes it back on /api/pair so the
+    // step list is correct before the pairer re-confirms it over BLE.
+    cJSON_AddStringToObject(o, "family", keypad_family_str(ident.family));
     cJSON_AddBoolToObject(o, "online", true);
     cJSON_AddNumberToObject(o, "rssi", hit->second.rssi);
     cJSON_AddItemToArray(arr, o);
@@ -227,15 +251,17 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   if (mac.empty()) {
     return reply_error_(req, "400 Bad Request", "Missing keypad mac.");
   }
-  ESP_LOGI(TAG, "POST /api/pair mac=%s", mac.c_str());
+  // Family as identified by /api/keypads and echoed back by the browser. It
+  // sizes the step list shown during pairing; the pairer re-confirms it from
+  // the live advertisement before acting.
+  const KeypadFamily family = keypad_family_from_str(extract_json_str(body, "family").c_str());
+  ESP_LOGI(TAG, "POST /api/pair mac=%s family=%s", mac.c_str(), keypad_family_str(family));
 
   if (!self->cloud_.is_logged_in()) {
     return reply_error_(req, "401 Unauthorized", "Sign in first.");
   }
 
   // Confirm the MAC belongs to this account (and grab its pretty form + name).
-  // The protocol family is determined later by the pairer from the keypad's
-  // live BLE advertisement.
   std::vector<CloudClient::AccountDevice> devices;
   std::string err;
   if (!self->cloud_.list_devices(devices, err)) {
@@ -265,6 +291,7 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   // Build the pairer's request.
   KeypadPairer::Request kr;
   kr.keypad_mac  = found->mac_pretty;
+  kr.family      = family;
   kr.key_id     = static_cast<int>(std::strtol(key_id_hex.c_str(), nullptr, 16));
   kr.key        = std::move(key_bytes);
   kr.shared_token = self->shared_key_;
@@ -288,9 +315,10 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   cJSON_AddStringToObject(resp, "job_id", job_id.c_str());
   // Step labels for the progress stepper — the wizard renders these, so the
   // pairer stays the single source of truth for count, order and wording.
+  // The Vision family has one extra step (enabling the doorbell).
   cJSON *labels = cJSON_AddArrayToObject(resp, "labels");
-  for (uint8_t i = 0; i < KeypadPairer::step_count(); ++i) {
-    cJSON_AddItemToArray(labels, cJSON_CreateString(KeypadPairer::step_label(i)));
+  for (uint8_t i = 0; i < KeypadPairer::step_count(family); ++i) {
+    cJSON_AddItemToArray(labels, cJSON_CreateString(KeypadPairer::step_label(family, i)));
   }
   return reply_json_(req, json_take(resp).c_str());
 }

--- a/components/switchbot_keypad_bridge/pairing_ui.h
+++ b/components/switchbot_keypad_bridge/pairing_ui.h
@@ -6,7 +6,7 @@
 //   GET  /                       → embedded HTML (single self-contained page)
 //   POST /api/login              → {email,password} → {region} | 401
 //   GET  /api/keypads            → [ {mac, name, model, online, rssi} ]
-//   POST /api/pair               → {mac} → {job_id}
+//   POST /api/pair               → {mac} → {job_id, labels: [step names]}
 //   GET  /api/pair/status        → {step, total, message, done, error}
 //
 // The server uses ESP-IDF's `esp_http_server` (already pulled in by NimBLE

--- a/components/switchbot_keypad_bridge/pairing_ui.h
+++ b/components/switchbot_keypad_bridge/pairing_ui.h
@@ -49,8 +49,11 @@ class PairingUi {
     this->html_len_ = len;
   }
 
-  // Called once after a successful pairing with the keypad's display name.
-  void set_on_paired_callback(std::function<void(const std::string &)> cb) {
+  // Called once after a successful pairing with the keypad's display name,
+  // pretty MAC and protocol family (the latter two feed the battery scan).
+  using OnPairedCallback = std::function<void(
+      const std::string &name, const std::string &mac, KeypadFamily family)>;
+  void set_on_paired_callback(OnPairedCallback cb) {
     this->on_paired_cb_ = std::move(cb);
   }
 
@@ -78,7 +81,7 @@ class PairingUi {
   std::array<uint8_t, 16> shared_key_{};
   const uint8_t *html_{nullptr};
   size_t         html_len_{0};
-  std::function<void(const std::string &)> on_paired_cb_;
+  OnPairedCallback on_paired_cb_;
   // Identify the pairing this UI started. The success handler matches
   // Status::job_id against pairing_job_id_ before firing on_paired_cb_,
   // so a previous job's lingering SUCCESS can never apply the wrong

--- a/components/switchbot_keypad_bridge/pairing_ui.h
+++ b/components/switchbot_keypad_bridge/pairing_ui.h
@@ -42,7 +42,8 @@ class PairingUi {
   // slot during pairing.
   void set_shared_key(const std::array<uint8_t, 16> &key) { this->shared_key_ = key; }
 
-  // The embedded UI page, baked into flash by codegen (see __init__.py).
+  // The embedded UI page, gzip-compressed and baked into flash by codegen
+  // (see __init__.py); served verbatim with Content-Encoding: gzip.
   // Not NUL-terminated, so the length is carried alongside the pointer.
   void set_html(const uint8_t *html, size_t len) {
     this->html_ = html;

--- a/components/switchbot_keypad_bridge/pairing_ui.h
+++ b/components/switchbot_keypad_bridge/pairing_ui.h
@@ -20,9 +20,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <string>
 
 #include "cloud_client.h"
+#include "keypad_advert.h"
 #include "keypad_pairer.h"
 
 namespace esphome {
@@ -90,6 +92,13 @@ class PairingUi {
   std::string    pairing_keypad_name_;
   std::string    pairing_job_id_;
   bool           success_notified_{false};
+
+  // Keypads identified from their BLE advertisement, keyed by pretty MAC. A
+  // keypad's model signature rides in the 0xFD3D service data, which for the
+  // Keypad Vision only arrives in the (intermittently received) scan response.
+  // Caching every positive identification keeps such a keypad listed on later
+  // scans where its service data was missed, as long as it's still in range.
+  std::map<std::string, KeypadIdent> identified_keypads_;
 };
 
 }  // namespace switchbot_keypad_bridge

--- a/components/switchbot_keypad_bridge/pairing_ui.html
+++ b/components/switchbot_keypad_bridge/pairing_ui.html
@@ -581,6 +581,10 @@
     </div>
 
     <div class="card" id="progress-card-content">
+      <!-- Placeholder steps, shown only until POST /api/pair responds (and
+           in the file:// design preview). The live stepper is rebuilt from
+           the `labels` array in the /api/pair response — the firmware's
+           step list is the single source of truth, this one is cosmetic. -->
       <ul class="stepper" id="progress-stepper">
         <li class="step active"><span class="indicator"></span>Connecting to keypad</li>
         <li class="step"><span class="indicator"></span>Discovering services</li>
@@ -837,6 +841,13 @@
     try {
       const r = await api('POST', '/api/pair', { mac: kp.mac });
       jobId = r.job_id;
+      /* Rebuild the stepper from the firmware's own step list — the static
+         <li> items above are only a placeholder while this request runs. */
+      if (Array.isArray(r.labels) && r.labels.length) {
+        document.getElementById('progress-stepper').innerHTML = r.labels.map(l =>
+          '<li class="step"><span class="indicator"></span>' + escapeHtml(l) + '</li>'
+        ).join('');
+      }
     } catch (err) {
       showResultError(err.message);
       return;

--- a/components/switchbot_keypad_bridge/pairing_ui.html
+++ b/components/switchbot_keypad_bridge/pairing_ui.html
@@ -273,7 +273,7 @@
     border-radius: var(--radius-card);
     border: 1.5px dashed var(--sb-divider);
   }
-  /* Spinner shown while /api/keypads runs (cloud call + ~4 s BLE scan). */
+  /* Spinner shown while /api/keypads runs (cloud call + ~8 s BLE scan). */
   .spinner {
     width: 30px; height: 30px;
     margin: 0 auto var(--sp-md);
@@ -329,6 +329,10 @@
     padding: 9px 0;
     font-size: 14px; color: var(--sb-support);
     position: relative;
+    /* Steps are injected once the firmware returns its label list; fade each
+       one in (JS staggers the per-item delay) so the stepper eases into view
+       instead of popping in all at once. */
+    animation: stepIn 320ms cubic-bezier(.22,.61,.36,1) both;
   }
   .step .indicator {
     width: 20px; height: 20px; border-radius: 50%;
@@ -356,6 +360,31 @@
     animation: spin 0.75s linear infinite;
   }
   @keyframes spin { to { transform: rotate(360deg); } }
+  @keyframes stepIn {
+    from { opacity: 0; transform: translateY(7px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  /* Loader shown in the stepper while /api/pair is in flight; swapped for the
+     real steps once the firmware returns its label list. The track line is
+     hidden and the stepper given a stable height, so the lone spinner sits dead
+     centre in the empty area instead of in a collapsed box. */
+  .stepper.loading {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 200px;
+  }
+  .stepper.loading::before { display: none; }
+  .stepper-loader { list-style: none; }
+  .stepper-loader .spinner {
+    display: block; margin: 0;          /* span is inline by default — needs a
+                                           block box for width/height to apply */
+    width: 30px; height: 30px; border-radius: 50%;
+    border: 3px solid var(--sb-divider);
+    border-top-color: var(--sb-theme);
+    animation: spin 0.8s linear infinite;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .step { animation: none; }
+  }
 
   /* ── Banners ── */
   .banner {
@@ -581,10 +610,10 @@
     </div>
 
     <div class="card" id="progress-card-content">
-      <!-- Placeholder steps, shown only until POST /api/pair responds (and
-           in the file:// design preview). The live stepper is rebuilt from
-           the `labels` array in the /api/pair response — the firmware's
-           step list is the single source of truth, this one is cosmetic. -->
+      <!-- These static steps exist only for the file:// design preview. At
+           runtime startPair() empties the stepper and fills it from the
+           `labels` array in the /api/pair response — the firmware's step list
+           is the single source of truth; nothing here is shown on-device. -->
       <ul class="stepper" id="progress-stepper">
         <li class="step active"><span class="indicator"></span>Connecting to keypad</li>
         <li class="step"><span class="indicator"></span>Discovering services</li>
@@ -749,7 +778,7 @@
   /* ── Keypad list ─────────────────────────────────────────────────────── */
 
   async function loadKeypads() {
-    // /api/keypads runs a ~4s BLE scan; lock the Rescan button so the user
+    // /api/keypads runs a ~8s BLE scan; lock the Rescan button so the user
     // can't fire concurrent scans by clicking again while one is running.
     const btn = document.getElementById('rescan-btn');
     if (btn.disabled) return;
@@ -758,7 +787,7 @@
     list.innerHTML =
       '<div class="empty-state">' +
         '<div class="spinner"></div>' +
-        'Searching for keypads…' +
+        'Searching for keypads nearby…' +
       '</div>';
     try {
       const keypads = await api('GET', '/api/keypads');
@@ -821,6 +850,12 @@
 
   async function startPair(kp) {
     currentKp = kp;
+    /* The real step list (labels) comes from the firmware in the /api/pair
+       response — never duplicated here. Until it arrives, show a loader so the
+       card is never empty; it's swapped for the real steps on response. */
+    const stepper = document.getElementById('progress-stepper');
+    stepper.classList.add('loading');
+    stepper.innerHTML = '<li class="stepper-loader"><span class="spinner"></span></li>';
     showScreen('progress');
     document.getElementById('progress-kp-name').textContent = kp.name;
     document.getElementById('progress-kp-mac').textContent = kp.mac;
@@ -833,19 +868,18 @@
     document.getElementById('progress-result-error').classList.add('hidden');
     setProgressHint('Pairing takes about 10 seconds.');
 
-    document.querySelectorAll('#progress-stepper .step').forEach(li => {
-      li.classList.remove('done', 'active');
-    });
-
     let jobId;
     try {
-      const r = await api('POST', '/api/pair', { mac: kp.mac });
+      const r = await api('POST', '/api/pair', { mac: kp.mac, family: kp.family });
       jobId = r.job_id;
-      /* Rebuild the stepper from the firmware's own step list — the static
-         <li> items above are only a placeholder while this request runs. */
+      /* Fill the stepper from the firmware's own step list — the single source
+         of truth for the steps, their count, order and wording. The per-item
+         animation-delay staggers the fade-in so the list eases in. */
       if (Array.isArray(r.labels) && r.labels.length) {
-        document.getElementById('progress-stepper').innerHTML = r.labels.map(l =>
-          '<li class="step"><span class="indicator"></span>' + escapeHtml(l) + '</li>'
+        stepper.classList.remove('loading');
+        stepper.innerHTML = r.labels.map((l, i) =>
+          '<li class="step" style="animation-delay:' + (i * 55) + 'ms">' +
+          '<span class="indicator"></span>' + escapeHtml(l) + '</li>'
         ).join('');
       }
     } catch (err) {

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
@@ -243,15 +243,12 @@ void SwitchbotKeypadBridge::loop() {
     });
   }
 
-  // Drain the RX queue. Doing a copy and clear limits memory allocation
-  // in the NimBLE thread side to the bare minimum, avoiding heap thrashing.
+  // Drain the RX queue. Swapping the vector out keeps the critical section
+  // free of allocation and copying, so the NimBLE task never waits on it.
   std::vector<QueuedEvent> pending;
   {
     std::lock_guard<std::mutex> lk(this->rx_mutex_);
-    if (!this->rx_queue_.empty()) {
-      pending = this->rx_queue_;
-      this->rx_queue_.clear();
-    }
+    pending.swap(this->rx_queue_);
   }
 
   for (const auto &ev : pending) {
@@ -282,6 +279,16 @@ void SwitchbotKeypadBridge::unpair() {
   if (!this->import_aes_key_()) {
     ESP_LOGE(TAG, "Key rotation failed — unpair aborted");
     return;
+  }
+
+  // Stop an in-flight battery scan window: the wizard's own blocking scans
+  // share the NimBLE scan singleton and must not race it.
+  if (this->battery_scan_active_.exchange(false)) {
+    NimBLEScan *scan = NimBLEDevice::getScan();
+    if (scan->isScanning()) {
+      scan->stop();
+    }
+    scan->clearResults();
   }
 
   // Forget the paired keypad name and its battery-scan identity.
@@ -493,6 +500,11 @@ void SwitchbotKeypadBridge::on_rx_frame_(const std::string &frame) {
     return;
   }
 
+  // DOORBELL is deliberately left out of the replay filter: under a fixed
+  // session IV a second legitimate press in the same connection produces the
+  // exact same ciphertext, and dropping it would swallow real rings. Worst
+  // case for a replayed doorbell frame is a spurious chime; a replayed
+  // lock/unlock changes security state, so only those are filtered.
   if (command.type == CommandType::LOCK || command.type == CommandType::UNLOCK) {
     if (ciphertext_seen) {
       ESP_LOGW(TAG, "Dropping action: ciphertext replay within session");

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
@@ -14,6 +14,7 @@
 #include "aes_ctr.h"
 #include "ble_utils.h"
 #include "keypad_advert.h"
+#include "mac_utils.h"
 
 namespace esphome {
 namespace switchbot_keypad_bridge {

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
@@ -1,13 +1,19 @@
 #include "switchbot_keypad_bridge.h"
 
+#include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <vector>
 
 #include <esp_mac.h>
 #include <esp_random.h>
 #include <psa/crypto.h>
 
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+#include "aes_ctr.h"
+#include "ble_utils.h"
+#include "keypad_advert.h"
 
 namespace esphome {
 namespace switchbot_keypad_bridge {
@@ -30,16 +36,6 @@ constexpr uint8_t SPOOFED_OUI[3] = {0xB0, 0xE9, 0xFE};
 constexpr uint8_t ADVERTISING_MFG_DATA[] = {0x27, 0x09, 0x00, 0x10,
                                             0xA5, 0xB8, 0x00, 0x00, 0x00};
 
-// Plain-text command frames as decoded from the keypad. The state-poll
-// constant is a 3-byte prefix because the trailing byte is a per-family
-// model suffix (varies between keypad models).
-constexpr uint8_t FRAME_LOCK[8]              = {0x0F, 0x4E, 0x01, 0x03, 0x00, 0x00, 0x00, 0x00};
-constexpr uint8_t FRAME_ACTION[4]            = {0x0F, 0x4E, 0x01, 0x03};
-constexpr uint8_t FRAME_STATE_POLL_PREFIX[3] = {0x0F, 0x4F, 0x81};
-// Doorbell press (Keypad Vision). A short, distinct 2-byte opcode the keypad
-// sends on the shared slot when its doorbell button is pressed.
-constexpr uint8_t FRAME_DOORBELL[2]          = {0x01, 0x03};
-
 // Encrypted response payloads sent back to the keypad on lock/unlock.
 constexpr uint8_t RESPONSE_LOCK[5]   = {0x90, 0x0A, 0x7F, 0x7F, 0x00};
 constexpr uint8_t RESPONSE_UNLOCK[5] = {0x98, 0x08, 0x7F, 0x7F, 0x00};
@@ -57,33 +53,15 @@ constexpr size_t   MAX_PAYLOAD_LEN     = 32;
 // Shape: 57 00 00 00 0F 21 03 <key_id>
 constexpr size_t   SESSION_IV_REQ_MIN  = 8;
 
-// Unlock frame layout: [hdr(4) | method | marker(0x80) | index | ...]
-constexpr size_t   UNLOCK_METHOD_OFFSET = 4;
-constexpr size_t   UNLOCK_MARKER_OFFSET = 5;
-constexpr size_t   UNLOCK_INDEX_OFFSET  = 6;
-constexpr uint8_t  UNLOCK_MARKER        = 0x80;
-constexpr uint8_t  UNLOCK_INDEX_BASE    = 0x0A;
-
 constexpr size_t   AES_KEY_SIZE   = 16;
 constexpr size_t   AES_IV_SIZE    = 16;
 constexpr size_t   IV_RESPONSE_HEADER = 4;  // session_iv_response_ prefix before the IV bytes
 
-}  // namespace
+// Battery advert scan: one short active window per interval.
+constexpr uint32_t BATTERY_SCAN_DURATION_MS = 5000;
+constexpr uint32_t BATTERY_SCAN_RETRY_MS    = 30000;
 
-const char *unlock_method_name(UnlockMethod method) {
-  switch (method) {
-    case UnlockMethod::FINGERPRINT:
-      return "fingerprint";
-    case UnlockMethod::PIN:
-      return "pin";
-    case UnlockMethod::NFC:
-      return "nfc";
-    case UnlockMethod::FACE:
-      return "face";
-    default:
-      return "unknown";
-  }
-}
+}  // namespace
 
 // ---------------------------------------------------------------------------
 // NimBLE callback bridges
@@ -114,6 +92,18 @@ class SwitchbotKeypadBridge::RxCharCallbacks : public NimBLECharacteristicCallba
     if (value.empty())
       return;
     this->parent_->push_rx_(value);
+  }
+
+ private:
+  SwitchbotKeypadBridge *parent_;
+};
+
+class SwitchbotKeypadBridge::BatteryScanCallbacks : public NimBLEScanCallbacks {
+ public:
+  explicit BatteryScanCallbacks(SwitchbotKeypadBridge *parent) : parent_(parent) {}
+
+  void onResult(const NimBLEAdvertisedDevice *adv) override {
+    this->parent_->handle_battery_advert_(adv);
   }
 
  private:
@@ -170,6 +160,17 @@ void SwitchbotKeypadBridge::setup() {
       this->keypad_text_sensor_->publish_state("Unpaired");
     }
   }
+  this->keypad_paired_ = have_keypad;
+
+  // Restore the keypad MAC + family used by the battery advert scan. Missing
+  // for keypads paired before this field existed — the scan learns it then.
+  this->keypad_info_pref_ =
+      global_preferences->make_preference<KeypadInfo>(0x534B4D43UL /* 'SKMC' */);
+  if (!this->keypad_info_pref_.load(&this->keypad_info_)) {
+    this->keypad_info_ = KeypadInfo{};
+  }
+  this->battery_scan_callbacks_ = new BatteryScanCallbacks(this);
+  this->next_battery_scan_at_ = millis() + BATTERY_SCAN_RETRY_MS;
 
   if (!this->prepare_keys_() || !this->prepare_ble_()) {
     this->mark_failed();
@@ -179,13 +180,17 @@ void SwitchbotKeypadBridge::setup() {
            NimBLEDevice::getAddress().toString().c_str());
 
   this->pairing_ui_.set_shared_key(this->shared_key_);
-  this->pairing_ui_.set_on_paired_callback([this](const std::string &name) {
-    // Runs on the HTTP-server task — keep it minimal: stash the name and
-    // raise a flag. loop() (the main task) publishes the text sensor,
-    // writes NVS and stops the server.
-    this->pending_keypad_name_ = name;
-    this->pending_pair_apply_.store(true, std::memory_order_release);
-  });
+  this->pairing_ui_.set_on_paired_callback(
+      [this](const std::string &name, const std::string &mac,
+             KeypadFamily family) {
+        // Runs on the HTTP-server task — keep it minimal: stash the fields and
+        // raise a flag. loop() (the main task) publishes the text sensor,
+        // writes NVS and stops the server.
+        this->pending_keypad_name_ = name;
+        this->pending_keypad_mac_ = mac;
+        this->pending_keypad_family_ = family;
+        this->pending_pair_apply_.store(true, std::memory_order_release);
+      });
   // Pairing mode: with no keypad paired yet, open the wizard right away
   // so the very first pairing needs no button press.
   if (!have_keypad) {
@@ -207,7 +212,21 @@ void SwitchbotKeypadBridge::loop() {
     char buf[KEYPAD_NAME_MAX] = {};
     name.copy(buf, sizeof(buf) - 1);
     const bool saved = this->keypad_name_pref_.save(&buf);
+
+    // Persist the keypad's MAC + family for the battery advert scan.
+    KeypadInfo info{};
+    if (parse_mac_pretty(this->pending_keypad_mac_, info.mac)) {
+      info.family = static_cast<uint8_t>(this->pending_keypad_family_);
+      info.valid = 1;
+    }
+    this->keypad_info_ = info;
+    this->keypad_info_pref_.save(&this->keypad_info_);
     global_preferences->sync();
+
+    this->keypad_paired_ = true;
+    this->last_battery_ = -1;
+    // Pick the new keypad's battery up shortly, not a full interval away.
+    this->next_battery_scan_at_ = millis() + 10000;
 
     if (this->keypad_text_sensor_ != nullptr) {
       this->keypad_text_sensor_->publish_state(name);
@@ -247,6 +266,11 @@ void SwitchbotKeypadBridge::loop() {
       this->on_rx_frame_(ev.frame);
     }
   }
+
+  if (this->battery_level_sensor_ != nullptr) {
+    this->apply_pending_battery_();
+    this->maybe_start_battery_scan_();
+  }
 }
 
 void SwitchbotKeypadBridge::unpair() {
@@ -260,12 +284,19 @@ void SwitchbotKeypadBridge::unpair() {
     return;
   }
 
-  // Forget the paired keypad name.
+  // Forget the paired keypad name and its battery-scan identity.
   char empty[KEYPAD_NAME_MAX] = {};
   this->keypad_name_pref_.save(&empty);
+  this->keypad_info_ = KeypadInfo{};
+  this->keypad_info_pref_.save(&this->keypad_info_);
   global_preferences->sync();
   if (this->keypad_text_sensor_ != nullptr) {
     this->keypad_text_sensor_->publish_state("Unpaired");
+  }
+  this->keypad_paired_ = false;
+  this->last_battery_ = -1;
+  if (this->battery_level_sensor_ != nullptr) {
+    this->battery_level_sensor_->publish_state(NAN);
   }
 
   // Invalidate any in-flight BLE session — it is keyed to the old secret.
@@ -293,6 +324,10 @@ void SwitchbotKeypadBridge::dump_config() {
   ESP_LOGCONFIG(TAG, "SwitchBot Keypad Bridge:");
   ESP_LOGCONFIG(TAG, "  BLE address: %s", NimBLEDevice::getAddress().toString().c_str());
   ESP_LOGCONFIG(TAG, "  Pairing UI: port 80");
+  if (this->battery_level_sensor_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Battery scan interval: %us",
+                  static_cast<unsigned>(this->battery_scan_interval_ms_ / 1000));
+  }
   if (this->is_failed()) {
     ESP_LOGE(TAG, "  Initialization failed - see previous errors");
   }
@@ -451,8 +486,8 @@ void SwitchbotKeypadBridge::on_rx_frame_(const std::string &frame) {
 
   ESP_LOGD(TAG, "RX %s", format_hex_pretty(plaintext, ct_len).c_str());
 
-  DecodedCommand command;
-  if (!this->decode_command_(plaintext, ct_len, command)) {
+  const DecodedCommand command = decode_lock_command(plaintext, ct_len);
+  if (command.type == CommandType::UNKNOWN) {
     ESP_LOGI(TAG, "Unhandled command: %s", format_hex_pretty(plaintext, ct_len).c_str());
     this->send_ack_(header);
     return;
@@ -483,40 +518,6 @@ void SwitchbotKeypadBridge::send_session_iv_() {
   this->clear_replay_history_();
   this->iv_established_ = true;
   this->notify_(this->session_iv_response_.data(), this->session_iv_response_.size());
-}
-
-bool SwitchbotKeypadBridge::decode_command_(const uint8_t *plaintext, size_t length,
-                                            DecodedCommand &out) const {
-  if (length == sizeof(FRAME_LOCK) && std::memcmp(plaintext, FRAME_LOCK, sizeof(FRAME_LOCK)) == 0) {
-    out.type = CommandType::LOCK;
-    return true;
-  }
-  if (length == 4 &&
-      std::memcmp(plaintext, FRAME_STATE_POLL_PREFIX, sizeof(FRAME_STATE_POLL_PREFIX)) == 0) {
-    out.type = CommandType::STATE_POLL;
-    return true;
-  }
-  if (length == sizeof(FRAME_DOORBELL) &&
-      std::memcmp(plaintext, FRAME_DOORBELL, sizeof(FRAME_DOORBELL)) == 0) {
-    out.type = CommandType::DOORBELL;
-    return true;
-  }
-  if (length >= 8 && std::memcmp(plaintext, FRAME_ACTION, sizeof(FRAME_ACTION)) == 0 &&
-      plaintext[UNLOCK_MARKER_OFFSET] == UNLOCK_MARKER) {
-    out.type = CommandType::UNLOCK;
-    const uint8_t method_byte = plaintext[UNLOCK_METHOD_OFFSET];
-    out.method = static_cast<UnlockMethod>(method_byte);
-    const uint8_t idx_byte = plaintext[UNLOCK_INDEX_OFFSET];
-    // Original keypad: index encoded as 0x0A + zero-based slot. Vision: raw
-    // zero-based byte (we only have a single capture with 0x00, so this is
-    // a best-effort decode). Heuristic: if the byte ≥ 0x0A, treat as the
-    // original biased encoding; otherwise pass it through as the raw index.
-    out.credential_index = (idx_byte >= UNLOCK_INDEX_BASE)
-                               ? static_cast<int16_t>(idx_byte - UNLOCK_INDEX_BASE)
-                               : static_cast<int16_t>(idx_byte);
-    return true;
-  }
-  return false;
 }
 
 void SwitchbotKeypadBridge::handle_command_(const FrameHeader &header, const DecodedCommand &command) {
@@ -599,27 +600,9 @@ void SwitchbotKeypadBridge::notify_(const uint8_t *data, size_t length) {
 // ---------------------------------------------------------------------------
 
 bool SwitchbotKeypadBridge::aes_ctr_xcrypt_(const uint8_t *input, size_t length, uint8_t *output) {
-  psa_cipher_operation_t op = PSA_CIPHER_OPERATION_INIT;
-  size_t out_len = 0;
-  size_t finish_len = 0;
-
-  psa_status_t status = psa_cipher_encrypt_setup(&op, this->aes_key_handle_, PSA_ALG_CTR);
-  if (status == PSA_SUCCESS) {
-    status = psa_cipher_set_iv(&op, this->session_iv_response_.data() + IV_RESPONSE_HEADER, AES_IV_SIZE);
-  }
-  if (status == PSA_SUCCESS) {
-    status = psa_cipher_update(&op, input, length, output, length, &out_len);
-  }
-  if (status == PSA_SUCCESS) {
-    status = psa_cipher_finish(&op, output + out_len, length - out_len, &finish_len);
-  }
-
-  if (status != PSA_SUCCESS) {
-    ESP_LOGE(TAG, "AES-CTR operation failed (%d)", static_cast<int>(status));
-    psa_cipher_abort(&op);
-    return false;
-  }
-  return true;
+  return aes_ctr_xcrypt(this->aes_key_handle_,
+                        this->session_iv_response_.data() + IV_RESPONSE_HEADER,
+                        input, output, length);
 }
 
 void SwitchbotKeypadBridge::rotate_session_iv_() {
@@ -693,6 +676,125 @@ void SwitchbotKeypadBridge::publish_doorbell_() {
     this->keypad_event_->trigger("Doorbell");
   }
   this->on_doorbell_callbacks_.call();
+}
+
+// ---------------------------------------------------------------------------
+// Keypad battery (advertisement scan)
+// ---------------------------------------------------------------------------
+
+void SwitchbotKeypadBridge::maybe_start_battery_scan_() {
+  const uint32_t now = millis();
+
+  if (this->battery_scan_active_) {
+    // NimBLE drops isScanning() when the window elapses or stop() ran.
+    if (!NimBLEDevice::getScan()->isScanning()) {
+      this->battery_scan_active_ = false;
+      NimBLEDevice::getScan()->clearResults();
+      this->next_battery_scan_at_ = now + this->battery_scan_interval_ms_;
+    }
+    return;
+  }
+
+  if (static_cast<int32_t>(now - this->next_battery_scan_at_) < 0) {
+    return;
+  }
+
+  // The scan singleton is shared with the pairing flows (which run blocking
+  // scans), and the keypad does not advertise while it holds a connection to
+  // us — defer rather than fight either.
+  if (!this->keypad_paired_ || this->pairing_ui_.is_running() ||
+      (this->server_ != nullptr && this->server_->getConnectedCount() > 0) ||
+      NimBLEDevice::getScan()->isScanning()) {
+    this->next_battery_scan_at_ = now + BATTERY_SCAN_RETRY_MS;
+    return;
+  }
+
+  NimBLEScan *scan = NimBLEDevice::getScan();
+  scan->setScanCallbacks(this->battery_scan_callbacks_, false);
+  configure_switchbot_scan(scan);
+  if (scan->start(BATTERY_SCAN_DURATION_MS, false, true)) {
+    this->battery_scan_active_ = true;
+    ESP_LOGD(TAG, "Battery scan window opened (%u ms)",
+             static_cast<unsigned>(BATTERY_SCAN_DURATION_MS));
+  } else {
+    ESP_LOGW(TAG, "Battery scan failed to start");
+    this->next_battery_scan_at_ = now + BATTERY_SCAN_RETRY_MS;
+  }
+}
+
+void SwitchbotKeypadBridge::handle_battery_advert_(const NimBLEAdvertisedDevice *adv) {
+  // The callbacks stay registered on the shared scan singleton, so pairing
+  // scans fire them too — only act inside our own scan window.
+  if (!this->battery_scan_active_.load(std::memory_order_relaxed)) {
+    return;
+  }
+
+  const std::array<uint8_t, 6> mac = addr_bytes(adv->getAddress());
+  const std::vector<uint8_t> sd = switchbot_service_data(adv);
+
+  KeypadFamily family;
+  if (this->keypad_info_.valid != 0) {
+    if (std::memcmp(mac.data(), this->keypad_info_.mac, mac.size()) != 0) return;
+    family = static_cast<KeypadFamily>(this->keypad_info_.family);
+  } else {
+    // Keypad paired before the MAC was persisted: adopt the first advert
+    // matching a known keypad signature (loop() persists it).
+    const KeypadIdent ident = identify_keypad(sd.data(), sd.size());
+    if (!ident.is_keypad) return;
+    family = ident.family;
+  }
+
+  std::string mfr;
+  if (adv->haveManufacturerData()) {
+    mfr = adv->getManufacturerData();
+  }
+  const int battery = parse_keypad_battery(
+      family, sd.data(), sd.size(),
+      reinterpret_cast<const uint8_t *>(mfr.data()), mfr.size());
+  if (battery < 0) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lk(this->rx_mutex_);
+  this->battery_advert_value_ = battery;
+  std::memcpy(this->battery_advert_mac_, mac.data(), mac.size());
+  this->battery_advert_family_ = static_cast<uint8_t>(family);
+  this->battery_advert_pending_ = true;
+}
+
+void SwitchbotKeypadBridge::apply_pending_battery_() {
+  int value;
+  uint8_t mac[6];
+  uint8_t family;
+  {
+    std::lock_guard<std::mutex> lk(this->rx_mutex_);
+    if (!this->battery_advert_pending_) return;
+    this->battery_advert_pending_ = false;
+    value = this->battery_advert_value_;
+    std::memcpy(mac, this->battery_advert_mac_, sizeof(mac));
+    family = this->battery_advert_family_;
+  }
+
+  if (this->keypad_info_.valid == 0) {
+    std::memcpy(this->keypad_info_.mac, mac, sizeof(this->keypad_info_.mac));
+    this->keypad_info_.family = family;
+    this->keypad_info_.valid = 1;
+    this->keypad_info_pref_.save(&this->keypad_info_);
+    global_preferences->sync();
+    ESP_LOGI(TAG, "Learned keypad MAC %02X:%02X:%02X:%02X:%02X:%02X from advertisement",
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  }
+
+  // Got what we came for — close the scan window early.
+  if (this->battery_scan_active_ && NimBLEDevice::getScan()->isScanning()) {
+    NimBLEDevice::getScan()->stop();
+  }
+
+  ESP_LOGD(TAG, "Keypad battery: %d%%", value);
+  if (this->battery_level_sensor_ != nullptr && value != this->last_battery_) {
+    this->last_battery_ = value;
+    this->battery_level_sensor_->publish_state(static_cast<float>(value));
+  }
 }
 
 }  // namespace switchbot_keypad_bridge

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
@@ -11,7 +11,6 @@
 
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
-#include "aes_ctr.h"
 #include "ble_utils.h"
 #include "keypad_advert.h"
 #include "mac_utils.h"
@@ -45,18 +44,7 @@ constexpr uint8_t RESPONSE_UNLOCK[5] = {0x98, 0x08, 0x7F, 0x7F, 0x00};
 constexpr uint8_t STATE_PAYLOAD_TAIL[13] = {0x08, 0x08, 0x41, 0x00, 0x00, 0x00, 0x00,
                                             0x80, 0xF2, 0xFB, 0x00, 0x00, 0x00};
 
-// Encrypted protocol framing.
-constexpr uint8_t  PROTOCOL_MAGIC      = 0x57;
-constexpr size_t   ENCRYPTED_HEADER    = 4;     // [0x57, key_id, seq_a, seq_b]
-constexpr size_t   MAX_PAYLOAD_LEN     = 32;
-
-// Session IV negotiation: first frame received after connect.
-// Shape: 57 00 00 00 0F 21 03 <key_id>
-constexpr size_t   SESSION_IV_REQ_MIN  = 8;
-
-constexpr size_t   AES_KEY_SIZE   = 16;
-constexpr size_t   AES_IV_SIZE    = 16;
-constexpr size_t   IV_RESPONSE_HEADER = 4;  // session_iv_response_ prefix before the IV bytes
+constexpr size_t AES_KEY_SIZE = 16;
 
 // Battery advert scan: one short active window per interval.
 constexpr uint32_t BATTERY_SCAN_DURATION_MS = 5000;
@@ -255,10 +243,10 @@ void SwitchbotKeypadBridge::loop() {
   for (const auto &ev : pending) {
     if (ev.type == QueuedEvent::CONNECT) {
       ESP_LOGI(TAG, "Keypad connected");
-      this->reset_session_state_();
+      this->session_.reset();
     } else if (ev.type == QueuedEvent::DISCONNECT) {
       ESP_LOGI(TAG, "Keypad disconnected, restarting advertising");
-      this->reset_session_state_();
+      this->session_.reset();
       NimBLEDevice::startAdvertising();
     } else if (ev.type == QueuedEvent::RX) {
       this->on_rx_frame_(ev.frame);
@@ -307,9 +295,10 @@ void SwitchbotKeypadBridge::unpair() {
     this->battery_level_sensor_->publish_state(NAN);
   }
 
-  // Invalidate any in-flight BLE session — it is keyed to the old secret.
-  this->reset_session_state_();
-  this->shared_slot_id_ = 0x00;
+  // Invalidate any in-flight BLE session — it is keyed to the old secret —
+  // and forget the learned token slot along with it.
+  this->session_.reset();
+  this->session_.forget_slot();
 
   // Re-enter pairing mode straight away with the rotated key.
   this->pairing_ui_.set_shared_key(this->shared_key_);
@@ -368,6 +357,7 @@ bool SwitchbotKeypadBridge::import_aes_key_() {
     ESP_LOGE(TAG, "AES key import failed (%d)", static_cast<int>(status));
     return false;
   }
+  this->session_.set_aes_key(this->aes_key_handle_);
   return true;
 }
 
@@ -425,112 +415,17 @@ bool SwitchbotKeypadBridge::prepare_ble_() {
 // ---------------------------------------------------------------------------
 
 void SwitchbotKeypadBridge::on_rx_frame_(const std::string &frame) {
-  ESP_LOGV(TAG, "RX WIRE %zu bytes: %s", frame.size(),
-           format_hex_pretty(reinterpret_cast<const uint8_t *>(frame.data()), frame.size()).c_str());
-
-  if (this->is_session_iv_request_(frame)) {
-    // The IV request advertises which key_id the keypad will use for the
-    // rest of the session (`57 00 00 00 0F 21 03 <key_id>`). Adapt to it —
-    // Original/Touch uses 0x88, Vision/Vision Pro uses 0xC6.
-    const uint8_t requested_slot = static_cast<uint8_t>(frame[7]);
-    if (requested_slot != this->shared_slot_id_) {
-      ESP_LOGI(TAG, "Token slot: 0x%02X", requested_slot);
-      this->shared_slot_id_ = requested_slot;
-    }
-    ESP_LOGD(TAG, "IV request");
-    this->send_session_iv_();
-    return;
-  }
-
-  if (frame.size() <= ENCRYPTED_HEADER ||
-      static_cast<uint8_t>(frame[0]) != PROTOCOL_MAGIC) {
-    ESP_LOGD(TAG, "Ignoring non-protocol frame (size=%zu)", frame.size());
-    return;
-  }
-
-  const FrameHeader header{static_cast<uint8_t>(frame[1]), static_cast<uint8_t>(frame[2]),
-                           static_cast<uint8_t>(frame[3])};
-
-  if (header.key_id != this->shared_slot_id_) {
-    ESP_LOGD(TAG, "Ignoring frame with unexpected key_id=0x%02X", header.key_id);
-    return;
-  }
-
-  // Refuse encrypted frames before the IV handshake completed in this session.
-  // A captured ciphertext from a previous connection would otherwise decrypt
-  // against the wrong (or stale) IV and ride on whatever lock_state_ is set.
-  if (!this->iv_established_) {
-    ESP_LOGW(TAG, "Dropping encrypted frame: no IV negotiated in this session");
-    return;
-  }
-
-  // The protocol echoes IV[0..1] back as the seq_a/seq_b header bytes.
-  // Reject anything that does not match the IV we just issued — this blocks
-  // cross-session replay of captured ciphertexts.
-  if (header.seq_a != this->session_iv_response_[IV_RESPONSE_HEADER] ||
-      header.seq_b != this->session_iv_response_[IV_RESPONSE_HEADER + 1]) {
-    ESP_LOGW(TAG, "Dropping frame: seq_a/seq_b mismatch (cross-session replay?)");
-    return;
-  }
-
-  const size_t ct_len = frame.size() - ENCRYPTED_HEADER;
-  if (ct_len > MAX_PAYLOAD_LEN) {
-    ESP_LOGW(TAG, "Dropping frame with invalid payload length: %zu", ct_len);
-    return;
-  }
-
-  const uint8_t *ciphertext = reinterpret_cast<const uint8_t *>(frame.data() + ENCRYPTED_HEADER);
-
-  // Intra-session replay protection for state-changing actions: under a
-  // fixed session IV, identical plaintexts produce identical ciphertexts.
-  // We only flag duplicates that decode to a side-effecting command — state
-  // polls are idempotent and a legitimate keypad emits them repeatedly.
-  const bool ciphertext_seen = this->is_replayed_ciphertext_(ciphertext, ct_len);
-
-  uint8_t plaintext[MAX_PAYLOAD_LEN];
-  if (!this->aes_ctr_xcrypt_(ciphertext, ct_len, plaintext)) {
-    return;  // error already logged
-  }
-
-  ESP_LOGD(TAG, "RX %s", format_hex_pretty(plaintext, ct_len).c_str());
-
-  const DecodedCommand command = decode_lock_command(plaintext, ct_len);
-  if (command.type == CommandType::UNKNOWN) {
-    ESP_LOGI(TAG, "Unhandled command: %s", format_hex_pretty(plaintext, ct_len).c_str());
-    this->send_ack_(header);
-    return;
-  }
-
-  // DOORBELL is deliberately left out of the replay filter: under a fixed
-  // session IV a second legitimate press in the same connection produces the
-  // exact same ciphertext, and dropping it would swallow real rings. Worst
-  // case for a replayed doorbell frame is a spurious chime; a replayed
-  // lock/unlock changes security state, so only those are filtered.
-  if (command.type == CommandType::LOCK || command.type == CommandType::UNLOCK) {
-    if (ciphertext_seen) {
-      ESP_LOGW(TAG, "Dropping action: ciphertext replay within session");
+  switch (this->session_.process_frame(frame)) {
+    case LockSession::Action::SEND_IV:
+      this->notify_(this->session_.iv_response(), this->session_.iv_response_size());
       return;
-    }
-    this->record_ciphertext_(ciphertext, ct_len);
+    case LockSession::Action::COMMAND:
+      this->handle_command_(this->session_.header(), this->session_.command());
+      return;
+    case LockSession::Action::NONE:
+    default:
+      return;  // dropped — the session logged why
   }
-
-  this->handle_command_(header, command);
-}
-
-bool SwitchbotKeypadBridge::is_session_iv_request_(const std::string &frame) const {
-  return frame.size() >= SESSION_IV_REQ_MIN &&
-         static_cast<uint8_t>(frame[0]) == PROTOCOL_MAGIC &&
-         static_cast<uint8_t>(frame[1]) == 0x00 &&
-         static_cast<uint8_t>(frame[5]) == 0x21 &&
-         static_cast<uint8_t>(frame[6]) == 0x03;
-}
-
-void SwitchbotKeypadBridge::send_session_iv_() {
-  this->rotate_session_iv_();
-  // A new IV invalidates any ciphertext sniffed under the previous one.
-  this->clear_replay_history_();
-  this->iv_established_ = true;
-  this->notify_(this->session_iv_response_.data(), this->session_iv_response_.size());
 }
 
 void SwitchbotKeypadBridge::handle_command_(const FrameHeader &header, const DecodedCommand &command) {
@@ -582,87 +477,23 @@ void SwitchbotKeypadBridge::handle_state_poll_(const FrameHeader &header) {
 // ---------------------------------------------------------------------------
 
 void SwitchbotKeypadBridge::send_ack_(const FrameHeader &header) {
-  const uint8_t ack[ENCRYPTED_HEADER] = {0x01, header.key_id, header.seq_a, header.seq_b};
+  const uint8_t ack[LockSession::HEADER_LEN] = {0x01, header.key_id, header.seq_a, header.seq_b};
   this->notify_(ack, sizeof(ack));
 }
 
 void SwitchbotKeypadBridge::send_encrypted_response_(const FrameHeader &header,
                                                     const uint8_t *plaintext, size_t length) {
-  if (length > MAX_PAYLOAD_LEN) {
-    ESP_LOGE(TAG, "Response payload too large (%zu > %zu)", length, MAX_PAYLOAD_LEN);
-    return;
+  uint8_t packet[LockSession::MAX_PACKET];
+  const size_t n = this->session_.encrypt_response(header, plaintext, length, packet);
+  if (n == 0) {
+    return;  // error already logged
   }
-  uint8_t packet[ENCRYPTED_HEADER + MAX_PAYLOAD_LEN];
-  packet[0] = 0x01;
-  packet[1] = header.key_id;
-  packet[2] = header.seq_a;
-  packet[3] = header.seq_b;
-  if (!this->aes_ctr_xcrypt_(plaintext, length, packet + ENCRYPTED_HEADER)) {
-    return;
-  }
-  this->notify_(packet, ENCRYPTED_HEADER + length);
+  this->notify_(packet, n);
 }
 
 void SwitchbotKeypadBridge::notify_(const uint8_t *data, size_t length) {
   this->tx_characteristic_->setValue(data, length);
   this->tx_characteristic_->notify();
-}
-
-// ---------------------------------------------------------------------------
-// Crypto
-// ---------------------------------------------------------------------------
-
-bool SwitchbotKeypadBridge::aes_ctr_xcrypt_(const uint8_t *input, size_t length, uint8_t *output) {
-  return aes_ctr_xcrypt(this->aes_key_handle_,
-                        this->session_iv_response_.data() + IV_RESPONSE_HEADER,
-                        input, output, length);
-}
-
-void SwitchbotKeypadBridge::rotate_session_iv_() {
-  for (size_t i = 0; i < AES_IV_SIZE; i += 4) {
-    const uint32_t value = esp_random();
-    std::memcpy(this->session_iv_response_.data() + IV_RESPONSE_HEADER + i, &value, 4);
-  }
-  ESP_LOGV(TAG, "IV rotated: %s",
-           format_hex_pretty(this->session_iv_response_.data() + IV_RESPONSE_HEADER, AES_IV_SIZE).c_str());
-}
-
-// ---------------------------------------------------------------------------
-// Anti-replay
-// ---------------------------------------------------------------------------
-
-void SwitchbotKeypadBridge::reset_session_state_() {
-  this->iv_established_ = false;
-  this->clear_replay_history_();
-}
-
-void SwitchbotKeypadBridge::clear_replay_history_() {
-  this->replay_head_ = 0;
-  for (auto &entry : this->replay_history_) {
-    entry.length = 0;
-  }
-}
-
-bool SwitchbotKeypadBridge::is_replayed_ciphertext_(const uint8_t *ciphertext, size_t length) const {
-  if (length == 0 || length > MAX_REPLAY_PAYLOAD) {
-    return false;
-  }
-  for (const auto &entry : this->replay_history_) {
-    if (entry.length == length && std::memcmp(entry.data.data(), ciphertext, length) == 0) {
-      return true;
-    }
-  }
-  return false;
-}
-
-void SwitchbotKeypadBridge::record_ciphertext_(const uint8_t *ciphertext, size_t length) {
-  if (length == 0 || length > MAX_REPLAY_PAYLOAD) {
-    return;
-  }
-  ReplayEntry &slot = this->replay_history_[this->replay_head_];
-  std::memcpy(slot.data.data(), ciphertext, length);
-  slot.length = length;
-  this->replay_head_ = (this->replay_head_ + 1) % REPLAY_HISTORY_SIZE;
 }
 
 // ---------------------------------------------------------------------------

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
@@ -13,6 +13,7 @@
 
 #include "esphome/components/button/button.h"
 #include "esphome/components/event/event.h"
+#include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
@@ -20,6 +21,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 
+#include "lock_protocol.h"
 #include "pairing_ui.h"
 
 // NimBLE's log_common.h defines LOG_LEVEL_* as plain macros, which collide
@@ -38,18 +40,30 @@ namespace switchbot_keypad_bridge {
 // Upper bound (including the trailing NUL) on the persisted keypad name.
 constexpr size_t KEYPAD_NAME_MAX = 48;
 
-enum class UnlockMethod : uint8_t {
-  UNKNOWN = 0x00,
-  PIN = 0x04,
-  NFC = 0x08,
-  FINGERPRINT = 0x0C,
-  FACE = 0x18,
-};
+// UnlockMethod / CommandType / DecodedCommand and the frame decoding live in
+// lock_protocol.h — the transport-free half of the protocol.
 
-const char *unlock_method_name(UnlockMethod method);
-
+// ── Concurrency model ───────────────────────────────────────────────────────
+// Four execution contexts touch this component. The rule of thumb: only the
+// main task acts; every other context hands data over and returns.
+//
+//   1. ESPHome main task — setup()/loop() and everything they call. The only
+//      context that publishes entities, writes NVS, or mutates session and
+//      battery-scan state.
+//   2. NimBLE host task — server/characteristic callbacks and the battery
+//      scan callback. They only enqueue: connect/disconnect/RX frames into
+//      rx_queue_, battery adverts into the battery_advert_* fields — both
+//      under rx_mutex_, both drained by loop().
+//   3. HTTP-server task (pairing wizard) — signals a finished pairing through
+//      the pending_keypad_* fields plus the pending_pair_apply_ flag. The
+//      fields are written first, then the flag is stored with release
+//      semantics; loop() exchanges the flag with acquire before reading them.
+//      When adding a pending field, write it BEFORE the flag store.
+//   4. Pairing FreeRTOS task ("kp-pair") — owned by KeypadPairer, which
+//      exposes progress as Status snapshots copied under its own mutex.
 class SwitchbotKeypadBridge : public Component {
   SUB_TEXT_SENSOR(keypad)
+  SUB_SENSOR(battery_level)
 
  public:
   void setup() override;
@@ -61,6 +75,7 @@ class SwitchbotKeypadBridge : public Component {
   void set_pairing_ui_html(const uint8_t *html, size_t len) {
     this->pairing_ui_.set_html(html, len);
   }
+  void set_battery_scan_interval(uint32_t ms) { this->battery_scan_interval_ms_ = ms; }
 
   bool is_pairing_active() const { return this->pairing_ui_.is_running(); }
 
@@ -81,20 +96,14 @@ class SwitchbotKeypadBridge : public Component {
  protected:
   class ServerCallbacks;
   class RxCharCallbacks;
+  class BatteryScanCallbacks;
   friend class ServerCallbacks;
   friend class RxCharCallbacks;
+  friend class BatteryScanCallbacks;
 
   enum class LockState : uint8_t {
     LOCKED = 0x81,
     UNLOCKED = 0x91,
-  };
-
-  enum class CommandType : uint8_t {
-    UNKNOWN,
-    LOCK,
-    UNLOCK,
-    STATE_POLL,
-    DOORBELL,
   };
 
   // 4-byte transport header echoed back on every encrypted exchange.
@@ -104,10 +113,14 @@ class SwitchbotKeypadBridge : public Component {
     uint8_t seq_b;
   };
 
-  struct DecodedCommand {
-    CommandType type{CommandType::UNKNOWN};
-    UnlockMethod method{UnlockMethod::UNKNOWN};
-    int16_t credential_index{-1};
+  // Identity of the paired keypad, persisted to NVS at pairing time so the
+  // battery scan can match its advertisement after a reboot. `valid == 0`
+  // for keypads paired before this field existed — the scan then learns the
+  // MAC from the first recognised keypad advert and persists it.
+  struct KeypadInfo {
+    uint8_t mac[6]{};   // big-endian, as printed
+    uint8_t family{0};  // KeypadFamily
+    uint8_t valid{0};
   };
 
   // ----- Configuration / setup -----------------------------------------------
@@ -128,7 +141,6 @@ class SwitchbotKeypadBridge : public Component {
   bool is_session_iv_request_(const std::string &frame) const;
   void send_session_iv_();
 
-  bool decode_command_(const uint8_t *plaintext, size_t length, DecodedCommand &out) const;
   void handle_command_(const FrameHeader &header, const DecodedCommand &command);
   void handle_state_poll_(const FrameHeader &header);
 
@@ -155,6 +167,16 @@ class SwitchbotKeypadBridge : public Component {
   void publish_lock_();
   void publish_unlock_(UnlockMethod method, int index);
   void publish_doorbell_();
+
+  // ----- Keypad battery (advertisement scan) ----------------------------------
+
+  // The keypad broadcasts its battery level in its BLE advertisement (the
+  // command frames it sends us never carry it). A short active scan picks
+  // the advert up while the bridge keeps advertising as the lock.
+  void maybe_start_battery_scan_();
+  void apply_pending_battery_();
+  // Runs on the NimBLE host task — parses the advert and queues the result.
+  void handle_battery_advert_(const NimBLEAdvertisedDevice *adv);
 
   // ----- BLE handles ---------------------------------------------------------
 
@@ -186,6 +208,8 @@ class SwitchbotKeypadBridge : public Component {
   // read once the flag is observed.
   std::atomic<bool> pending_pair_apply_{false};
   std::string pending_keypad_name_;
+  std::string pending_keypad_mac_;
+  KeypadFamily pending_keypad_family_{KeypadFamily::ORIGINAL};
 
   // ----- ESPHome wiring ------------------------------------------------------
 
@@ -229,6 +253,27 @@ class SwitchbotKeypadBridge : public Component {
   std::array<ReplayEntry, REPLAY_HISTORY_SIZE> replay_history_{};
   size_t replay_head_{0};
   bool iv_established_{false};
+
+  // ----- Keypad battery state --------------------------------------------------
+
+  ESPPreferenceObject keypad_info_pref_;
+  KeypadInfo keypad_info_{};
+  bool keypad_paired_{false};
+
+  uint32_t battery_scan_interval_ms_{15 * 60 * 1000};
+  uint32_t next_battery_scan_at_{0};  // millis() deadline for the next scan
+  // Written by loop(), read by the NimBLE scan callback as its "is this our
+  // scan window?" gate — hence atomic.
+  std::atomic<bool> battery_scan_active_{false};
+  BatteryScanCallbacks *battery_scan_callbacks_{nullptr};
+  int last_battery_{-1};  // last published value; -1 = nothing published yet
+
+  // Latest advert parsed by the NimBLE scan callback, handed to loop()
+  // under rx_mutex_ (same pattern as the RX queue).
+  bool battery_advert_pending_{false};
+  int battery_advert_value_{-1};
+  uint8_t battery_advert_mac_[6]{};
+  uint8_t battery_advert_family_{0};
 };
 
 // Home Assistant button that unpairs the keypad: forgets it, rotates the

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <NimBLEDevice.h>
 #include <psa/crypto.h>
 
 #include <array>
@@ -22,17 +21,8 @@
 #include "esphome/core/preferences.h"
 
 #include "lock_protocol.h"
+#include "nimble_compat.h"
 #include "pairing_ui.h"
-
-// NimBLE's log_common.h defines LOG_LEVEL_* as plain macros, which collide
-// with identically-named members of ESPHome enums included downstream.
-// ESPHome uses ESPHOME_LOG_LEVEL_* for its own logging, so these undefs are safe.
-#undef LOG_LEVEL_NONE
-#undef LOG_LEVEL_ERROR
-#undef LOG_LEVEL_WARN
-#undef LOG_LEVEL_INFO
-#undef LOG_LEVEL_DEBUG
-#undef LOG_LEVEL_CRITICAL
 
 namespace esphome {
 namespace switchbot_keypad_bridge {

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
@@ -21,6 +21,7 @@
 #include "esphome/core/preferences.h"
 
 #include "lock_protocol.h"
+#include "lock_session.h"
 #include "nimble_compat.h"
 #include "pairing_ui.h"
 
@@ -30,8 +31,10 @@ namespace switchbot_keypad_bridge {
 // Upper bound (including the trailing NUL) on the persisted keypad name.
 constexpr size_t KEYPAD_NAME_MAX = 48;
 
-// UnlockMethod / CommandType / DecodedCommand and the frame decoding live in
-// lock_protocol.h — the transport-free half of the protocol.
+// The protocol layers live next door: lock_protocol.h decodes plaintext
+// frames, lock_session.h owns the encrypted-session state machine (IV,
+// anti-replay, transport crypto). This component is the NimBLE transport
+// and the ESPHome-facing business logic on top of them.
 
 // ── Concurrency model ───────────────────────────────────────────────────────
 // Four execution contexts touch this component. The rule of thumb: only the
@@ -96,13 +99,6 @@ class SwitchbotKeypadBridge : public Component {
     UNLOCKED = 0x91,
   };
 
-  // 4-byte transport header echoed back on every encrypted exchange.
-  struct FrameHeader {
-    uint8_t key_id;
-    uint8_t seq_a;
-    uint8_t seq_b;
-  };
-
   // Identity of the paired keypad, persisted to NVS at pairing time so the
   // battery scan can match its advertisement after a reboot. `valid == 0`
   // for keypads paired before this field existed — the scan then learns the
@@ -127,9 +123,9 @@ class SwitchbotKeypadBridge : public Component {
 
   // ----- BLE write handling --------------------------------------------------
 
+  // Validation, decryption and decoding live in LockSession; the bridge
+  // dispatches the resulting Action and owns the business logic.
   void on_rx_frame_(const std::string &frame);
-  bool is_session_iv_request_(const std::string &frame) const;
-  void send_session_iv_();
 
   void handle_command_(const FrameHeader &header, const DecodedCommand &command);
   void handle_state_poll_(const FrameHeader &header);
@@ -139,18 +135,6 @@ class SwitchbotKeypadBridge : public Component {
   void send_ack_(const FrameHeader &header);
   void send_encrypted_response_(const FrameHeader &header, const uint8_t *plaintext, size_t length);
   void notify_(const uint8_t *data, size_t length);
-
-  // ----- Crypto (AES-CTR is symmetric, so a single primitive covers both ways) -
-
-  bool aes_ctr_xcrypt_(const uint8_t *input, size_t length, uint8_t *output);
-  void rotate_session_iv_();
-
-  // ----- Anti-replay ---------------------------------------------------------
-
-  void reset_session_state_();
-  void clear_replay_history_();
-  bool is_replayed_ciphertext_(const uint8_t *ciphertext, size_t length) const;
-  void record_ciphertext_(const uint8_t *ciphertext, size_t length);
 
   // ----- Eventing ------------------------------------------------------------
 
@@ -215,11 +199,6 @@ class SwitchbotKeypadBridge : public Component {
   std::array<uint8_t, 16> shared_key_{};
   ESPPreferenceObject shared_key_pref_;
   ESPPreferenceObject keypad_name_pref_;
-  // Token-slot key_id the keypad uses post-pairing. Auto-learned from the
-  // IV-request frame the keypad sends as the first message of every session
-  // (Original/Touch=0x88, Vision/Vision Pro=0xC6, …). 0x00 = not yet seen;
-  // no encrypted frame is accepted until the IV handshake has set it.
-  uint8_t shared_slot_id_{0x00};
 
   // ----- Runtime state -------------------------------------------------------
 
@@ -228,21 +207,9 @@ class SwitchbotKeypadBridge : public Component {
   psa_key_id_t aes_key_handle_{PSA_KEY_ID_NULL};
   LockState lock_state_{LockState::LOCKED};
 
-  // 20-byte session IV response: [0x01, 0x00, 0x00, 0x00, IV(16)].
-  // The trailing 16 bytes are also used as the AES-CTR IV for the live session.
-  std::array<uint8_t, 20> session_iv_response_{0x01, 0x00, 0x00, 0x00};
-
-  // Per-session anti-replay state. Reset on connect, disconnect, and on
-  // every IV re-negotiation.
-  static constexpr size_t REPLAY_HISTORY_SIZE = 8;
-  static constexpr size_t MAX_REPLAY_PAYLOAD = 32;
-  struct ReplayEntry {
-    std::array<uint8_t, MAX_REPLAY_PAYLOAD> data{};
-    size_t length{0};
-  };
-  std::array<ReplayEntry, REPLAY_HISTORY_SIZE> replay_history_{};
-  size_t replay_head_{0};
-  bool iv_established_{false};
+  // Per-connection encrypted-session state (token slot, IV, anti-replay,
+  // transport crypto). Only ever touched from the main task.
+  LockSession session_{};
 
   // ----- Keypad battery state --------------------------------------------------
 

--- a/switchbot-keypad-bridge.yaml
+++ b/switchbot-keypad-bridge.yaml
@@ -2,9 +2,15 @@ esphome:
   name: switchbot-keypad-bridge
 
 esp32:
+  board: seeed_xiao_esp32s3
   variant: esp32s3
+  flash_size: 8MB
   framework:
     type: esp-idf
+
+psram:
+  mode: octal
+  speed: 80MHz
 
 external_components:
   - source: github://pierluigizagaria/switchbot-keypad-bridge
@@ -15,6 +21,7 @@ wifi:
   password: !secret wifi_password
 
 logger:
+  level: VERBOSE
 
 api:
 
@@ -33,6 +40,11 @@ switchbot_keypad_bridge:
 
   keypad:
     name: "Keypad"
+
+  # Keypad battery, read from its BLE advertisement once per scan interval.
+  battery_level:
+    name: "Keypad Battery"
+  # battery_scan_interval: 15min
 
   unpair_button:
     name: "Unpair"


### PR DESCRIPTION
Closes #10 

## What

Adds a **keypad battery level** sensor to the bridge and hardens keypad
detection and pairing along the way.

The bridge emulates a Lock Ultra, so the keypad's battery never appears in
the command frames it sends. Instead — exactly like Home Assistant's native
SwitchBot integration — the level is read from the keypad's own BLE
advertisement, decoded the pySwitchbot way (no cloud SKU list, no device
name): Original/Touch from the `0xFD3D` service data, Vision from the
manufacturer data.

## Changes

### Feature
- **Battery sensor** (`battery_level:`): periodic background BLE scan while no
  keypad session is live, matched against the paired keypad's MAC+family
  (persisted in NVS), published as a diagnostic `%` entity. Configurable
  `battery_scan_interval` (default 15 min) with an early post-boot scan so HA
  isn't blank. Re-learn fallback for keypads paired before this feature.
- **Vision doorbell** is now an explicit, Vision-only pairing step
  ("Force-enabling doorbell") instead of a hidden command.

### Detection robustness
- The Keypad Vision's model signature rides in the `0xFD3D` service data,
  which only arrives in the (intermittent) BLE scan response. The scan
  previously gated service data behind "strongest RSSI seen", so an adv packet
  could shadow the scan response and hide a keypad — with two keypads in range
  it flakily showed only one. Now service data is captured from any packet that
  carries it, the scan window is 8 s, and every positive identification is
  cached by MAC so a keypad in range stays listed even when a later scan misses
  its service response.
- The identified `KeypadFamily` is carried from the UI through `/api/pair` into
  the pairer, so the wizard shows the correct step list; the pairer re-confirms
  it from the live advert before acting.

### Refactors (no behaviour change)
- Extract the encrypted-session state machine into `LockSession`.
- Split pure protocol helpers into `lock_protocol`, `aes_ctr`, `ble_utils`,
  `mac_utils`; centralise the NimBLE `LOG_LEVEL_*` undef hack in
  `nimble_compat.h`.
- Build the wizard stepper from the firmware-supplied step list (single source
  of truth) and embed the pairing UI gzip-compressed.
- Stepper UX: starts empty and fills from firmware labels with a staggered
  fade-in and a centred loader (no skeleton/placeholder).