### PR TITLE
Feat/bridge to lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 # 🔐 SwitchBot Keypad Bridge
 
-**Use a SwitchBot Keypad without a SwitchBot Lock.**
+**Use a SwitchBot Keypad locally, with or without a SwitchBot Lock.**
 
-An ESP32 that impersonates a SwitchBot Lock over Bluetooth LE — a genuine keypad
-pairs to it, and every PIN, fingerprint, NFC tag and face unlock becomes a
-Home Assistant event. The keypad never knows it isn't talking to a real lock.
+An ESP32 that impersonates a SwitchBot Lock over Bluetooth LE. A genuine keypad
+links to it, and every PIN, fingerprint, NFC tag and face unlock becomes a
+Home Assistant event — or, optionally, gets relayed to a real SwitchBot Lock
+through the bridge. The keypad still thinks it is talking to a lock; you decide
+whether that lock is virtual, physical, or both.
 
 [![ESPHome](https://img.shields.io/badge/ESPHome-external__component-1d97d4?logo=esphome&logoColor=white)](https://esphome.io/)
 [![ESP32](https://img.shields.io/badge/ESP32-ESP--IDF%20%2B%20NimBLE-e7352c?logo=espressif&logoColor=white)](https://www.espressif.com/)
 [![Home Assistant](https://img.shields.io/badge/Home%20Assistant-events%20%26%20triggers-03a9f4?logo=homeassistant&logoColor=white)](https://www.home-assistant.io/)
 [![Buy Me A Coffee](https://img.shields.io/badge/support-buy%20me%20a%20coffee-FFDD00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/pierluigizagaria)
 
-<img src="docs/pairing.gif" alt="Pairing a SwitchBot Keypad through the on-device wizard" width="320">
+<img src="docs/pairing.gif" alt="Linking a SwitchBot Keypad through the on-device wizard" width="320">
 
-*The on-device pairing wizard — no Python scripts, no BLE sniffing, no laptop.*
+*The on-device setup wizard — no Python scripts, no BLE sniffing, no laptop.*
 
 </div>
 
@@ -25,22 +27,26 @@ Home Assistant event. The keypad never knows it isn't talking to a real lock.
 
 - 🔓 **No SwitchBot Lock required** — repurpose a keypad as a standalone, fully
   local door/access controller.
+- 🔒 **Optional physical lock relay** — link a real SwitchBot Lock in the same
+  wizard and the bridge forwards keypad protocol messages over encrypted BLE.
 - 📟 **Every SwitchBot keypad works** — Keypad, Keypad Touch, Keypad Vision and
   Vision Pro: that's the whole lineup. Touch and Vision are tested on real
   hardware; the other two speak the exact same protocols.
-- 📲 **On-device pairing wizard** — the ESP32 serves a small web page: sign in
-  to your SwitchBot account, pick the keypad, done.
+- 📲 **On-device setup wizard** — the ESP32 serves a small web page: sign in to
+  your SwitchBot account, pick the keypad, optionally link the lock, done.
 - 👤 **Knows who unlocked** — every unlock carries the method (`pin` /
   `fingerprint` / `nfc` / `face`) and the credential slot, so you can act per user.
 - 🔔 **Doorbell, no lock needed** — on Keypad Vision the doorbell button is
-  enabled automatically during pairing (the app normally hides it until a lock
+  enabled automatically during setup (the app normally hides it until a lock
   is bound) and each press fires its own Home Assistant event.
-- 🔋 **Battery monitoring** — the keypad's battery level, exposed as a
-  diagnostic sensor.
-- 🔐 **Keys never leave the device** — the AES-128 session key is generated on
-  the ESP32 and stored in NVS; it is never in your YAML or git.
-- 🏠 **100% local after pairing** — the cloud is contacted exactly once, during
-  pairing. Day-to-day operation is pure BLE + ESPHome, no cloud round-trips.
+- 🔋 **Battery monitoring** — keypad and linked-lock battery levels, exposed
+  as diagnostic sensors.
+- 🔐 **Key material stays off YAML** — the keypad session key is generated on
+  the ESP32; optional lock relay keys are fetched during setup and stored in
+  NVS, never in your YAML or git.
+- 🏠 **100% local after setup** — the cloud is contacted only by the wizard
+  while setup runs. Day-to-day operation is pure BLE + ESPHome, no cloud
+  round-trips.
 
 ## 🧠 How it works
 
@@ -53,6 +59,7 @@ The bridge plays that part end to end:
 sequenceDiagram
     participant K as 🔢 SwitchBot Keypad
     participant B as 📡 ESP32 Bridge
+    participant L as 🔒 SwitchBot Lock<br/>(optional)
     participant HA as 🏠 Home Assistant
 
     Note over B: advertises as a SwitchBot Lock<br/>(spoofed B0:E9:FE MAC)
@@ -60,15 +67,21 @@ sequenceDiagram
     B->>B: decrypt → method + credential slot
     B-->>K: encrypted lock-style ACK
     B->>HA: event: Unlock (fingerprint, slot 0)
+    opt Physical lock linked
+        B->>L: encrypted unlock command
+        L-->>B: encrypted lock reply
+    end
     HA->>HA: your automation runs 🎉
 ```
 
-**Pairing** is the only step that touches the cloud, because the keypad ships
-encrypted with a *communication key* that lives on SwitchBot's servers, not in
-the app. The on-device wizard signs in to your account, fetches that key over
-HTTPS, uses it to re-encrypt the pairing handshake, and injects a fresh AES-128
-session key generated on the ESP32. From that moment the keypad and the bridge
-share a secret no one else has — including SwitchBot.
+**Setup** is the only step that touches the cloud. The keypad ships encrypted
+with a *communication key* that lives on SwitchBot's servers, not in the app, so
+the wizard signs in to your account, fetches that key over HTTPS, re-encrypts
+the pairing handshake, and injects a fresh AES-128 session key generated on the
+ESP32. If you link a physical lock, the wizard uses the lock communication key
+once, only in RAM, to install that same shared key into the lock, then verifies
+the shared-key slot. From that moment, keypad events and optional lock relay
+are local.
 
 Curious about the details — MAC spoofing, NimBLE, key rotation? See
 [Under the hood](#-under-the-hood).
@@ -76,7 +89,8 @@ Curious about the details — MAC spoofing, NimBLE, key rotation? See
 ## 🚀 Quick start
 
 **You need:** an ESP32 and a SwitchBot Keypad already added to your SwitchBot
-account.
+account. To enable physical relay, add a SwitchBot Lock to the same account and
+keep it near the ESP32 during setup.
 
 ### 1. Create `secrets.yaml`
 
@@ -95,25 +109,35 @@ pip install esphome
 esphome run switchbot-keypad-bridge.yaml
 ```
 
-### 3. Pair the keypad
+### 3. Link the keypad
 
-On first boot — with no keypad paired — the device opens its **pairing wizard**
+On first boot — with no keypad linked — the device opens its **setup wizard**
 automatically. Open it in a browser at `http://<device-ip>/` (the IP is in the
 boot log, or use Home Assistant's **Visit Device** link on the device page):
 
 1. Sign in with your SwitchBot account.
 2. Pick your keypad from the list.
-3. Wait for the wizard to finish — it closes itself when done.
+3. Wait for the wizard to finish.
 
 > The wizard recognises the keypad from its live BLE advertisement, so keep it
 > powered and within ~2 m of the ESP32 — out-of-range devices won't be listed.
 
-That's it. The keypad's name appears on the **Keypad** sensor and key presses
-arrive in Home Assistant as `Lock` / `Unlock` / `Doorbell` events.
+At this point the keypad's name appears on the **Keypad** sensor and key
+presses arrive in Home Assistant as `Lock` / `Unlock` / `Doorbell` events.
 
-> **Re-pairing** — to switch to a different keypad, press the **Unpair** button
-> in Home Assistant. The device forgets the current keypad, rotates its session
-> key, and re-opens the pairing wizard right away — no reboot.
+### 4. Optional: link a physical lock
+
+After keypad linking, the wizard unlocks the **Lock** tab. Pick a supported
+SwitchBot Lock from the list and wait for the link job to verify the encrypted
+BLE key. When it succeeds, the **Lock** sensor shows the linked lock name and
+keypad protocol messages are forwarded to that physical lock by default.
+
+Standalone mode still works with no linked lock: the bridge acknowledges the
+keypad locally and keeps publishing Home Assistant events.
+
+> **Re-linking** — to switch to a different keypad or lock, press the **Reset**
+> button in Home Assistant. The device forgets the current keypad and lock,
+> rotates its session key, and re-opens the setup wizard right away — no reboot.
 
 To stream logs at any time:
 
@@ -165,10 +189,38 @@ actions:
       message: Welcome home!
 ```
 
+## 🔒 Physical lock relay
+
+If you also own a SwitchBot Lock, the bridge can stay in the middle instead of
+being only a virtual lock. The setup wizard lists supported locks from the same
+SwitchBot account, checks that the selected lock is nearby, provisions the
+bridge's shared keypad/lock key into the lock, and verifies that shared slot
+before saving it.
+
+With a linked lock, side-effecting keypad command payloads are mirrored to the
+physical lock. Home Assistant events and the keypad response are local and
+immediate, so your automations keep seeing the same keypad actions while the
+lock relay runs in the background.
+
+The physical lock's encrypted reply is used only to log the relay outcome; it
+is not forwarded back to the keypad. If the BLE exchange fails, the keypad has
+already received its local lock-style response and the failure is reported in
+the ESPHome logs.
+
+```yaml
+switchbot_keypad_bridge:
+  linked_lock:
+    name: "Lock"
+```
+
+Supported lock families: Lock, Lock Lite, Lock Pro, Lock Pro Wi-Fi, Lock Ultra,
+Lock Vision and Lock Vision Pro. Keep the lock near the ESP32 during setup; the
+wizard only enables linking for locks it can see over BLE.
+
 ## 🔔 Doorbell (Keypad Vision)
 
 The official app hides the doorbell button until a SwitchBot Lock is bound to
-your account, so the bridge enables it automatically at the end of pairing.
+your account, so the bridge enables it automatically at the end of keypad setup.
 Each press fires the `on_doorbell` trigger and a `Doorbell` event:
 
 ```yaml
@@ -180,16 +232,20 @@ switchbot_keypad_bridge:
 
 > Vision family only — Original / Touch keypads have no doorbell button.
 
-## 🔋 Keypad battery
+## 🔋 Battery sensors
 
-The keypad broadcasts its battery level in its BLE advertisement. Add the
-`battery_level` sensor and the bridge picks it up with a short background scan
-(every 15 minutes by default):
+The keypad and linked physical lock broadcast their battery levels in BLE
+advertisements. Add either sensor and the bridge picks it up with a short
+shared background scan (every 15 minutes by default). If a lock advert does
+not include battery data, the value is left unchanged and retried at the next
+scan interval:
 
 ```yaml
 switchbot_keypad_bridge:
-  battery_level:
+  keypad_battery_level:
     name: "Keypad Battery"
+  lock_battery_level:
+    name: "Lock Battery"
   battery_scan_interval: 15min
 ```
 
@@ -198,10 +254,12 @@ switchbot_keypad_bridge:
 | Option | Type | Required | Description |
 |---|---|---|---|
 | `keypad_action` | event | no | Standard ESPHome `event` entity for keypad actions. Surfaces in HA as `event.<device>_action` with `Lock` / `Unlock` / `Doorbell` event types. |
-| `keypad` | text_sensor | no | Text sensor whose state is the display name of the paired keypad (Configuration category; empty if none). |
-| `battery_level` | sensor | no | Battery percentage of the paired keypad, read from its BLE advertisement (Diagnostic category). |
-| `battery_scan_interval` | time | no | How often the bridge scans for the keypad's advertisement to refresh `battery_level`. Default `15min`. |
-| `unpair_button` | button | no | Button that forgets the paired keypad, rotates the session key and re-opens the pairing wizard (no reboot). |
+| `keypad` | text_sensor | no | Diagnostic text sensor whose state is the linked keypad name, or `Unlinked` when no keypad is linked. |
+| `linked_lock` | text_sensor | no | Diagnostic text sensor whose state is the linked physical lock name, or `Unlinked` when relay mode is inactive. |
+| `keypad_battery_level` | sensor | no | Battery percentage of the linked keypad, read from its BLE advertisement (Diagnostic category). |
+| `lock_battery_level` | sensor | no | Battery percentage of the linked physical lock, read from its BLE advertisement (Diagnostic category). |
+| `battery_scan_interval` | time | no | How often the bridge refreshes keypad and lock battery sensors with the shared advertisement scan. Default `15min`. |
+| `reset_button` | button | no | Button that forgets the linked keypad and lock, rotates the session key and re-opens the setup wizard (no reboot). |
 | `on_lock` | automation | no | Triggered on every `lock` command. |
 | `on_unlock` | automation | no | Triggered on every `unlock` command — parameters `(std::string method, int index)`. |
 | `on_doorbell` | automation | no | Triggered on every doorbell press (Keypad Vision). No parameters. |
@@ -210,7 +268,7 @@ switchbot_keypad_bridge:
 
 - **Model detection over BLE** — the wizard identifies the keypad model from
   its live advertisement (pySwitchbot-style) and adapts the pairing protocol
-  accordingly, so even a future model pairs fine as long as it speaks one of
+  accordingly, so even a future model links fine as long as it speaks one of
   the two protocol families (*Original* or *Vision*).
 - **MAC spoofing** — at boot the bridge rewrites its BLE address into
   SwitchBot's OUI (`B0:E9:FE:xx:xx:xx`), preserving the chip-unique last three
@@ -221,8 +279,14 @@ switchbot_keypad_bridge:
   API that already ships with ESP-IDF. No extra Python or C++ dependencies —
   but it cannot coexist with ESPHome's own BLE stack (`esp32_ble`,
   `esp32_ble_tracker`, `esp32_improv`, …).
-- **Key hygiene** — unpairing rotates the session key, so a previously paired
-  keypad can no longer command the bridge.
+- **Physical lock relay** — the wizard recognises supported SwitchBot Lock
+  models from the cloud device type, uses the lock communication key only as a
+  transient setup key to provision the shared keypad/lock key, then verifies
+  that shared slot. Each relayed command opens a short BLE connection and
+  disconnects again using the shared key.
+- **Key hygiene** — reset rotates the shared keypad/lock session key and clears
+  the linked lock record, so a previously linked keypad can no longer command
+  the bridge.
 
 ## ❓ FAQ
 
@@ -232,17 +296,36 @@ switchbot_keypad_bridge:
 The keypad encrypts its pairing handshake with a *communication key* that is
 issued and stored by SwitchBot's servers — it is not in the app and cannot be
 read from the keypad itself. The wizard signs in from the ESP32, fetches that
-key over HTTPS, and uses it once to complete the handshake. After pairing the
-keypad talks to the bridge with a locally generated session key and the cloud
-is never contacted again.
+key over HTTPS, and uses it once to complete the keypad handshake. If you link
+a physical lock, the lock communication key is used once as a setup key to
+install the bridge's shared key into the lock. Relay uses that shared
+key/slot, not the lock's cloud communication key.
 </details>
 
 <details>
-<summary><b>Is anything cloud-dependent after pairing?</b></summary>
+<summary><b>Is anything cloud-dependent after setup?</b></summary>
 
-No. Unlock events, the doorbell, battery readings — everything runs over local
-BLE between the keypad and the ESP32, and over the native API between the
-ESP32 and Home Assistant.
+No. Unlock events, the doorbell, keypad battery readings and linked-lock relay
+all run over local BLE, then over the native API between the ESP32 and Home
+Assistant. The cloud is only used by the setup wizard.
+</details>
+
+<details>
+<summary><b>Do I still need a SwitchBot Lock?</b></summary>
+
+No. Standalone mode is still the default: the bridge acts as the lock, publishes
+Home Assistant events, and acknowledges the keypad locally. Linking a real lock
+is optional and only needed if you want the keypad to operate that physical
+lock directly.
+</details>
+
+<details>
+<summary><b>Which physical locks can be linked?</b></summary>
+
+The relay recognises the supported SwitchBot Lock families exposed by the cloud
+API: Lock, Lock Lite, Lock Pro, Lock Pro Wi-Fi, Lock Ultra, Lock Vision and Lock
+Vision Pro. The wizard only offers devices from your SwitchBot account that
+match those lock types.
 </details>
 
 <details>
@@ -272,9 +355,9 @@ producing a firmware that breaks at runtime. Remove the conflicting components
 
 ## ☕ Support
 
-If this project saved you the cost of a SwitchBot Lock — or just made your day —
-consider buying me a coffee. It's a great way to say thanks and keep the work
-going.
+If this project saved you the cost of a SwitchBot Lock, made your existing lock
+more useful, or just made your day, consider buying me a coffee. It's a great
+way to say thanks and keep the work going.
 
 <p align="center">
   <a href="https://buymeacoffee.com/pierluigizagaria">

--- a/components/switchbot_keypad_bridge/__init__.py
+++ b/components/switchbot_keypad_bridge/__init__.py
@@ -1,6 +1,6 @@
 """ESPHome integration: SwitchBot Keypad Bridge.
 
-This external component emulates a SwitchBot Lock BLE peripheral so a paired
+This external component emulates a SwitchBot Lock BLE peripheral so a linked
 SwitchBot Keypad can deliver encrypted unlock/lock commands. The bridge
 decrypts the frames in-place using mbed-TLS / PSA Crypto and exposes the
 decoded commands through two surfaces:
@@ -31,7 +31,6 @@ from esphome.components.esp32 import (
     include_builtin_idf_component,
 )
 from esphome.const import (
-    CONF_BATTERY_LEVEL,
     CONF_ID,
     CONF_TRIGGER_ID,
     DEVICE_CLASS_BATTERY,
@@ -51,8 +50,11 @@ MULTI_CONF = False
 
 CONF_KEYPAD_ACTION = "keypad_action"
 CONF_KEYPAD = "keypad"
+CONF_LINKED_LOCK = "linked_lock"
+CONF_KEYPAD_BATTERY_LEVEL = "keypad_battery_level"
+CONF_LOCK_BATTERY_LEVEL = "lock_battery_level"
 CONF_BATTERY_SCAN_INTERVAL = "battery_scan_interval"
-CONF_UNPAIR_BUTTON = "unpair_button"
+CONF_RESET_BUTTON = "reset_button"
 CONF_ON_LOCK = "on_lock"
 CONF_ON_UNLOCK = "on_unlock"
 CONF_ON_DOORBELL = "on_doorbell"
@@ -61,7 +63,7 @@ CONF_PAIRING_UI = "pairing_ui"
 # Auto-generated id for the progmem array that carries the embedded UI.
 CONF_PAIRING_UI_HTML_ID = "pairing_ui_html_id"
 
-# The pairing wizard is a single, self-contained HTML file living next to
+# The setup wizard is a single, self-contained HTML file living next to
 # this module. It doubles as a browser-openable design preview.
 PAIRING_UI_HTML = Path(__file__).parent / "pairing_ui.html"
 
@@ -70,7 +72,7 @@ switchbot_keypad_bridge_ns = cg.esphome_ns.namespace("switchbot_keypad_bridge")
 SwitchbotKeypadBridge = switchbot_keypad_bridge_ns.class_(
     "SwitchbotKeypadBridge", cg.Component
 )
-UnpairButton = switchbot_keypad_bridge_ns.class_("UnpairButton", button.Button)
+ResetButton = switchbot_keypad_bridge_ns.class_("ResetButton", button.Button)
 LockTrigger = switchbot_keypad_bridge_ns.class_(
     "LockTrigger", automation.Trigger.template()
 )
@@ -89,7 +91,7 @@ def _deprecated_pairing_ui(value):
     v = cv.boolean(value)
     if v is False:
         raise cv.Invalid(
-            "pairing_ui: false is no longer supported — the on-device pairing "
+            "pairing_ui: false is no longer supported — the on-device setup "
             "wizard is always compiled in. Remove this option."
         )
     LOGGER.warning(
@@ -104,12 +106,23 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(SwitchbotKeypadBridge),
         cv.Optional(CONF_KEYPAD_ACTION): event.event_schema(icon="mdi:gesture-tap"),
         cv.Optional(CONF_KEYPAD): text_sensor.text_sensor_schema(
-            icon="mdi:dialpad",
+            icon="mdi:lock-smart",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_LINKED_LOCK): text_sensor.text_sensor_schema(
+            icon="mdi:key",
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         # The keypad broadcasts its battery in its BLE advertisement; the
         # bridge picks it up with a short background scan once per interval.
-        cv.Optional(CONF_BATTERY_LEVEL): sensor.sensor_schema(
+        cv.Optional(CONF_KEYPAD_BATTERY_LEVEL): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            device_class=DEVICE_CLASS_BATTERY,
+            state_class=STATE_CLASS_MEASUREMENT,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            accuracy_decimals=0,
+        ),
+        cv.Optional(CONF_LOCK_BATTERY_LEVEL): sensor.sensor_schema(
             unit_of_measurement=UNIT_PERCENT,
             device_class=DEVICE_CLASS_BATTERY,
             state_class=STATE_CLASS_MEASUREMENT,
@@ -120,10 +133,10 @@ CONFIG_SCHEMA = cv.Schema(
             CONF_BATTERY_SCAN_INTERVAL, default="15min"
         ): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_PAIRING_UI): _deprecated_pairing_ui,
-        cv.Optional(CONF_UNPAIR_BUTTON): button.button_schema(
-            UnpairButton,
+        cv.Optional(CONF_RESET_BUTTON): button.button_schema(
+            ResetButton,
             entity_category=ENTITY_CATEGORY_CONFIG,
-            icon="mdi:link-off",
+            icon="mdi:restart",
         ),
         cv.GenerateID(CONF_PAIRING_UI_HTML_ID): cv.declare_id(cg.uint8),
         cv.Optional(CONF_ON_LOCK): automation.validate_automation(
@@ -167,7 +180,7 @@ def _final_validate(config):
                 "NimBLE benefits from the extra heap."
             )
 
-    # The pairing wizard binds to port 80 and reuses ESPHome's USE_WEBSERVER
+    # The setup wizard binds to port 80 and reuses ESPHome's USE_WEBSERVER
     # flag for HA discovery. Both clash with the official `web_server:`
     # component, which also defines USE_WEBSERVER and (by default) listens
     # on 80.
@@ -198,28 +211,38 @@ async def to_code(config):
         sens = await text_sensor.new_text_sensor(keypad_sensor_conf)
         cg.add(var.set_keypad_text_sensor(sens))
 
-    if battery_conf := config.get(CONF_BATTERY_LEVEL):
+    if linked_lock_conf := config.get(CONF_LINKED_LOCK):
+        sens = await text_sensor.new_text_sensor(linked_lock_conf)
+        cg.add(var.set_linked_lock_text_sensor(sens))
+
+    if battery_conf := config.get(CONF_KEYPAD_BATTERY_LEVEL):
         batt = await sensor.new_sensor(battery_conf)
-        cg.add(var.set_battery_level_sensor(batt))
+        cg.add(var.set_keypad_battery_level_sensor(batt))
+
+    if lock_battery_conf := config.get(CONF_LOCK_BATTERY_LEVEL):
+        batt = await sensor.new_sensor(lock_battery_conf)
+        cg.add(var.set_lock_battery_level_sensor(batt))
+
+    if config.get(CONF_KEYPAD_BATTERY_LEVEL) or config.get(CONF_LOCK_BATTERY_LEVEL):
         cg.add(
             var.set_battery_scan_interval(
                 config[CONF_BATTERY_SCAN_INTERVAL].total_milliseconds
             )
         )
 
-    if button_conf := config.get(CONF_UNPAIR_BUTTON):
+    if button_conf := config.get(CONF_RESET_BUTTON):
         btn = await button.new_button(button_conf)
         await cg.register_parented(btn, config[CONF_ID])
 
     # Make Home Assistant show the "Visit Device" link on the device page.
     # ESPHome's api component fills `webserver_port` in DeviceInfoResponse
     # iff USE_WEBSERVER is defined; HA uses that field to construct the URL.
-    # We piggy-back on the same flag so the pairing wizard gets discovered
+    # We piggy-back on the same flag so the setup wizard gets discovered
     # without requiring the user to also enable `web_server:` in YAML.
     cg.add_define("USE_WEBSERVER")
     cg.add_define("USE_WEBSERVER_PORT", 80)
 
-    # Bake the pairing wizard's HTML into the firmware image as a
+    # Bake the setup wizard's HTML into the firmware image as a
     # gzip-compressed PROGMEM array (~4x smaller; served with
     # Content-Encoding: gzip). `pairing_ui.html` is the single source of
     # truth — no generated header to commit, no build step to run by hand.
@@ -255,6 +278,13 @@ async def to_code(config):
     add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
     add_idf_sdkconfig_option("CONFIG_BT_BLUEDROID_ENABLED", False)
     add_idf_sdkconfig_option("CONFIG_BT_NIMBLE_ENABLED", True)
+    add_idf_sdkconfig_option("CONFIG_BT_NIMBLE_MAX_CONNECTIONS", 3)
+
+    # LWIP's default pool of 10 sockets is too tight for this device: the HA
+    # API, a log-stream client, mDNS, the wizard's httpd sessions and the
+    # cloud TLS client can all hold sockets at once — the TLS connect then
+    # fails with "failed to create socket" / "sock < 0".
+    add_idf_sdkconfig_option("CONFIG_LWIP_MAX_SOCKETS", 16)
 
     # Silence the NimBLE logger to keep heap and serial noise to a minimum.
     add_idf_sdkconfig_option("CONFIG_NIMBLE_CPP_LOG_LEVEL", 0)

--- a/components/switchbot_keypad_bridge/aes_ctr.cpp
+++ b/components/switchbot_keypad_bridge/aes_ctr.cpp
@@ -1,5 +1,8 @@
 #include "aes_ctr.h"
 
+#include <aes/esp_aes_gcm.h>
+#include <mbedtls/gcm.h>
+
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -53,6 +56,45 @@ bool aes_ctr_xcrypt_raw_key(const uint8_t key[16], const uint8_t iv[16],
   const bool ok = aes_ctr_xcrypt(key_id, iv, input, output, length);
   psa_destroy_key(key_id);
   return ok;
+}
+
+bool aes_gcm_encrypt_raw_key(const uint8_t key[16], const uint8_t iv[12],
+                             const uint8_t *input, uint8_t *output,
+                             size_t length, uint8_t tag[16]) {
+  esp_gcm_context ctx;
+  esp_aes_gcm_init(&ctx);
+  int rc = esp_aes_gcm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, key, 128);
+  if (rc == 0) {
+    rc = esp_aes_gcm_crypt_and_tag(&ctx, MBEDTLS_GCM_ENCRYPT, length,
+                                   iv, 12, nullptr, 0,
+                                   input, output, 16, tag);
+  }
+  esp_aes_gcm_free(&ctx);
+  if (rc != 0) {
+    ESP_LOGE(TAG, "AES-GCM encrypt failed (%d)", rc);
+    return false;
+  }
+  return true;
+}
+
+bool aes_gcm_decrypt_raw_key(const uint8_t key[16], const uint8_t iv[12],
+                             const uint8_t *input, uint8_t *output,
+                             size_t length) {
+  uint8_t ignored_tag[16];
+  esp_gcm_context ctx;
+  esp_aes_gcm_init(&ctx);
+  int rc = esp_aes_gcm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, key, 128);
+  if (rc == 0) {
+    rc = esp_aes_gcm_crypt_and_tag(&ctx, MBEDTLS_GCM_DECRYPT, length,
+                                   iv, 12, nullptr, 0,
+                                   input, output, sizeof(ignored_tag), ignored_tag);
+  }
+  esp_aes_gcm_free(&ctx);
+  if (rc != 0) {
+    ESP_LOGE(TAG, "AES-GCM decrypt failed (%d)", rc);
+    return false;
+  }
+  return true;
 }
 
 }  // namespace switchbot_keypad_bridge

--- a/components/switchbot_keypad_bridge/aes_ctr.h
+++ b/components/switchbot_keypad_bridge/aes_ctr.h
@@ -24,5 +24,19 @@ bool aes_ctr_xcrypt(psa_key_id_t key, const uint8_t iv[16],
 bool aes_ctr_xcrypt_raw_key(const uint8_t key[16], const uint8_t iv[16],
                             const uint8_t *input, uint8_t *output, size_t length);
 
+// AES-128-GCM helpers for newer SwitchBot locks. SwitchBot only carries the
+// first two bytes of the authentication tag in the command header, but the full
+// tag is still computed here so the caller can copy that prefix.
+bool aes_gcm_encrypt_raw_key(const uint8_t key[16], const uint8_t iv[12],
+                             const uint8_t *input, uint8_t *output,
+                             size_t length, uint8_t tag[16]);
+
+// Decrypt without authenticating a received short-tag SwitchBot packet. This
+// mirrors the official clients: firmware handles acceptance and only exposes a
+// partial tag to BLE clients, so there is no complete tag to verify locally.
+bool aes_gcm_decrypt_raw_key(const uint8_t key[16], const uint8_t iv[12],
+                             const uint8_t *input, uint8_t *output,
+                             size_t length);
+
 }  // namespace switchbot_keypad_bridge
 }  // namespace esphome

--- a/components/switchbot_keypad_bridge/background_job.h
+++ b/components/switchbot_keypad_bridge/background_job.h
@@ -1,0 +1,140 @@
+#pragma once
+
+// Shared progress/job scaffold for the setup wizard's background BLE tasks.
+// Protocol-specific classes keep their own Request and success payloads.
+
+#include <esp_timer.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <mutex>
+#include <string>
+#include <utility>
+
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+class BackgroundBleJob {
+ public:
+  enum class State : uint8_t {
+    IDLE,
+    RUNNING,
+    SUCCESS,
+    FAILED,
+  };
+
+  struct Status {
+    State state{State::IDLE};
+    uint8_t step{0};
+    uint8_t total{0};
+    std::string message;
+    std::string error;
+    std::string job_id;
+  };
+
+  State state() const {
+    std::lock_guard<std::mutex> lk(this->mu_);
+    return this->status_.state;
+  }
+
+ protected:
+  bool is_running_() const {
+    std::lock_guard<std::mutex> lk(this->mu_);
+    return this->status_.state == State::RUNNING;
+  }
+
+  void copy_status_base_(Status &out) const { out = this->status_; }
+
+  void mark_running_(uint8_t total, const std::string &job_id,
+                     const char *first_message) {
+    std::lock_guard<std::mutex> lk(this->mu_);
+    this->status_ = Status{};
+    this->status_.state = State::RUNNING;
+    this->status_.total = total;
+    this->status_.message = first_message != nullptr ? first_message : "";
+    this->status_.job_id = job_id;
+  }
+
+  void mark_step_(uint8_t step, const char *message, const char *tag) {
+    std::lock_guard<std::mutex> lk(this->mu_);
+    ESP_LOGI(tag, "Step %u/%u: %s", static_cast<unsigned>(step + 1),
+             static_cast<unsigned>(this->status_.total),
+             message != nullptr ? message : "");
+    this->status_.step = step;
+    this->status_.message = message != nullptr ? message : "";
+  }
+
+  void mark_failed_(const std::string &err, const char *tag,
+                    const char *job_label) {
+    ESP_LOGW(tag, "%s failed: %s", job_label, err.c_str());
+    std::lock_guard<std::mutex> lk(this->mu_);
+    this->status_.state = State::FAILED;
+    this->status_.error = err;
+    this->status_.message = err;
+  }
+
+  template <typename Owner, typename Request, typename Prepare>
+  std::string start_job_(Owner *owner, Request req, char job_prefix,
+                         const char *task_name, uint8_t total_steps,
+                         const char *first_message, const char *start_error,
+                         const char *tag, const char *job_label,
+                         TaskHandle_t *task_handle, Prepare prepare) {
+    char job_buf[16];
+    std::snprintf(job_buf, sizeof(job_buf), "%c-%lu", job_prefix,
+                  static_cast<unsigned long>(esp_timer_get_time() / 1000));
+    std::string job_id = job_buf;
+
+    auto *req_heap = new Request(std::move(req));
+    {
+      std::lock_guard<std::mutex> lk(this->mu_);
+      if (this->status_.state == State::RUNNING) {
+        delete req_heap;
+        return "";
+      }
+      prepare(*req_heap);
+      this->status_ = Status{};
+      this->status_.state = State::RUNNING;
+      this->status_.total = total_steps;
+      this->status_.message = first_message != nullptr ? first_message : "";
+      this->status_.job_id = job_id;
+    }
+
+    struct TaskCtx {
+      Owner *self;
+      Request *req;
+      TaskHandle_t *task_handle;
+    };
+    auto *ctx = new TaskCtx{owner, req_heap, task_handle};
+
+    BaseType_t rc = xTaskCreatePinnedToCore(
+        [](void *raw) {
+          auto *c = static_cast<TaskCtx *>(raw);
+          c->self->execute_(*c->req);
+          delete c->req;
+          if (c->task_handle != nullptr) {
+            *c->task_handle = nullptr;
+          }
+          delete c;
+          vTaskDelete(nullptr);
+        },
+        task_name, 8192, ctx, tskIDLE_PRIORITY + 2, task_handle, 0);
+
+    if (rc != pdPASS) {
+      delete ctx;
+      delete req_heap;
+      this->mark_failed_(start_error, tag, job_label);
+      return "";
+    }
+    return job_id;
+  }
+
+  mutable std::mutex mu_;
+  Status status_{};
+};
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/ble_utils.cpp
+++ b/components/switchbot_keypad_bridge/ble_utils.cpp
@@ -11,6 +11,21 @@ std::vector<uint8_t> switchbot_service_data(const NimBLEAdvertisedDevice *adv) {
   return std::vector<uint8_t>(sd.begin(), sd.end());
 }
 
+std::vector<uint8_t> switchbot_manufacturer_payload(const NimBLEAdvertisedDevice *adv) {
+  if (!adv->haveManufacturerData()) {
+    return {};
+  }
+  const std::string mfr = adv->getManufacturerData();
+  if (mfr.size() < 2) {
+    return {};
+  }
+  const auto *data = reinterpret_cast<const uint8_t *>(mfr.data());
+  if (data[0] != 0x69 || data[1] != 0x09) {
+    return {};
+  }
+  return std::vector<uint8_t>(data + 2, data + mfr.size());
+}
+
 std::array<uint8_t, 6> addr_bytes(const NimBLEAddress &addr) {
   std::array<uint8_t, 6> out{};
   const uint8_t *raw = addr.getBase()->val;  // little-endian
@@ -25,6 +40,47 @@ void configure_switchbot_scan(NimBLEScan *scan) {
   scan->setActiveScan(true);
   scan->setInterval(45);
   scan->setWindow(30);
+}
+
+bool connect_switchbot_service(const NimBLEAddress &target, uint32_t timeout_ms,
+                               const char *device_label,
+                               SwitchbotGattConnection &conn,
+                               std::string &error_out) {
+  conn = SwitchbotGattConnection{};
+  conn.client = NimBLEDevice::createClient();
+  if (conn.client == nullptr) {
+    error_out = "Could not allocate a BLE client for the ";
+    error_out += device_label;
+    error_out += ".";
+    return false;
+  }
+
+  conn.client->setConnectTimeout(timeout_ms);
+  if (!conn.client->connect(target)) {
+    NimBLEDevice::deleteClient(conn.client);
+    conn.client = nullptr;
+    error_out = "Could not connect to the ";
+    error_out += device_label;
+    error_out += ".";
+    return false;
+  }
+
+  NimBLERemoteService *svc =
+      conn.client->getService(NimBLEUUID(SWITCHBOT_SERVICE_UUID));
+  if (svc != nullptr) {
+    conn.rx = svc->getCharacteristic(NimBLEUUID(SWITCHBOT_RX_CHAR_UUID));
+    conn.tx = svc->getCharacteristic(NimBLEUUID(SWITCHBOT_TX_CHAR_UUID));
+  }
+  if (conn.rx == nullptr || conn.tx == nullptr) {
+    conn.client->disconnect();
+    NimBLEDevice::deleteClient(conn.client);
+    conn = SwitchbotGattConnection{};
+    error_out = "The ";
+    error_out += device_label;
+    error_out += " does not expose the SwitchBot GATT service.";
+    return false;
+  }
+  return true;
 }
 
 }  // namespace switchbot_keypad_bridge

--- a/components/switchbot_keypad_bridge/ble_utils.h
+++ b/components/switchbot_keypad_bridge/ble_utils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// Small NimBLE helpers shared by the bridge, the pairer and the pairing UI.
+// Small NimBLE helpers shared by the bridge, the pairer and the setup UI.
 //
 // keypad_advert.h and mac_utils.h are deliberately NimBLE-free; everything
 // here is the glue between NimBLE types and that raw-bytes world
@@ -16,9 +16,23 @@
 namespace esphome {
 namespace switchbot_keypad_bridge {
 
+constexpr const char *SWITCHBOT_SERVICE_UUID = "cba20d00-224d-11e6-9fb8-0002a5d5c51b";
+constexpr const char *SWITCHBOT_RX_CHAR_UUID = "cba20002-224d-11e6-9fb8-0002a5d5c51b";
+constexpr const char *SWITCHBOT_TX_CHAR_UUID = "cba20003-224d-11e6-9fb8-0002a5d5c51b";
+
+struct SwitchbotGattConnection {
+  NimBLEClient *client{nullptr};
+  NimBLERemoteCharacteristic *rx{nullptr};
+  NimBLERemoteCharacteristic *tx{nullptr};
+};
+
 // Read the SwitchBot service-data blob from an advertisement (UUID 0xFD3D,
 // with the legacy 0x0D00 as a fallback). Empty when not present.
 std::vector<uint8_t> switchbot_service_data(const NimBLEAdvertisedDevice *adv);
+
+// Read the SwitchBot manufacturer data after the 2-byte company id (0x0969).
+// Empty when the advert has no SwitchBot manufacturer payload.
+std::vector<uint8_t> switchbot_manufacturer_payload(const NimBLEAdvertisedDevice *adv);
 
 // Address bytes in big-endian (printed) order — NimBLE stores them reversed.
 std::array<uint8_t, 6> addr_bytes(const NimBLEAddress &addr);
@@ -27,6 +41,11 @@ std::array<uint8_t, 6> addr_bytes(const NimBLEAddress &addr);
 // drop any previous results. Active scanning is required — the keypad's
 // 0xFD3D service data rides in the scan response.
 void configure_switchbot_scan(NimBLEScan *scan);
+
+bool connect_switchbot_service(const NimBLEAddress &target, uint32_t timeout_ms,
+                               const char *device_label,
+                               SwitchbotGattConnection &conn,
+                               std::string &error_out);
 
 }  // namespace switchbot_keypad_bridge
 }  // namespace esphome

--- a/components/switchbot_keypad_bridge/cloud_client.cpp
+++ b/components/switchbot_keypad_bridge/cloud_client.cpp
@@ -6,6 +6,7 @@
 #include <cJSON.h>
 #include <esp_crt_bundle.h>
 #include <esp_http_client.h>
+#include <esp_system.h>
 #include <esp_tls.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
@@ -181,6 +182,18 @@ bool CloudClient::post_json_(const std::string &url, const std::string &body,
                                  static_cast<int>(body.size()));
 
   esp_err_t err = esp_http_client_perform(client);
+  if (err != ESP_OK) {
+    // Transient connect failures ("sock < 0") happen when a TLS handshake
+    // lands on a bad moment — BLE/WiFi radio contention or a short heap dip.
+    // Log the heap for diagnosis and retry once before giving up.
+    ESP_LOGW(TAG, "HTTPS attempt failed (%s), free heap %u — retrying once",
+             esp_err_to_name(err),
+             static_cast<unsigned>(esp_get_free_heap_size()));
+    esp_http_client_close(client);
+    out.clear();
+    vTaskDelay(pdMS_TO_TICKS(500));
+    err = esp_http_client_perform(client);
+  }
   bool ok = false;
   if (err != ESP_OK) {
     error_out = "HTTPS request failed: ";
@@ -294,7 +307,7 @@ bool CloudClient::list_devices(std::vector<AccountDevice> &out_devices,
   }
 
   // Return every account device that has a MAC. We don't classify here — the
-  // pairing UI decides which of these are keypads purely from each device's
+  // setup UI decides which of these are keypads purely from each device's
   // live BLE advertisement (see keypad_advert.h).
   std::vector<AccountDevice> picked;
   cJSON *item = nullptr;
@@ -302,12 +315,16 @@ bool CloudClient::list_devices(std::vector<AccountDevice> &out_devices,
     cJSON *mac = cJSON_GetObjectItemCaseSensitive(item, "device_mac");
     if (!cJSON_IsString(mac) || mac->valuestring == nullptr) continue;
     cJSON *name = cJSON_GetObjectItemCaseSensitive(item, "device_name");
+    cJSON *detail = cJSON_GetObjectItemCaseSensitive(item, "device_detail");
+    cJSON *type = detail != nullptr ? cJSON_GetObjectItemCaseSensitive(detail, "device_type")
+                                    : nullptr;
 
     AccountDevice dev;
     dev.mac          = compact_mac(mac->valuestring);
     dev.mac_pretty   = pretty_mac(dev.mac);
     dev.name         = (cJSON_IsString(name) && name->valuestring) ? name->valuestring
                                                                     : dev.mac_pretty;
+    dev.device_type  = (cJSON_IsString(type) && type->valuestring) ? type->valuestring : "";
     picked.push_back(std::move(dev));
   }
 
@@ -318,7 +335,7 @@ bool CloudClient::list_devices(std::vector<AccountDevice> &out_devices,
   return true;
 }
 
-bool CloudClient::fetch_keypad_key(const std::string &mac,
+bool CloudClient::fetch_device_key(const std::string &mac,
                                    std::string &key_id_hex,
                                    std::vector<uint8_t> &key_bytes,
                                    std::string &error_out) {

--- a/components/switchbot_keypad_bridge/cloud_client.h
+++ b/components/switchbot_keypad_bridge/cloud_client.h
@@ -14,10 +14,10 @@
 //   - the user's home region ("us" / "eu" / ...)
 //   - the account device list (keypad detection happens later, over BLE)
 //   - the keypad's current `communicationKey` (the cloud-issued key the
-//     keypad uses to talk to its currently paired lock)
+//     keypad uses to talk to its currently linked lock)
 //
 // The last one is what we re-encrypt the BLE pairing commands with —
-// the cloud client is the entry point of the on-device pairing wizard.
+// the cloud client is the entry point of the on-device setup wizard.
 
 #include <cstdint>
 #include <string>
@@ -30,13 +30,14 @@ class CloudClient {
  public:
   // Plain-data view of one account device as returned by
   // /wonder/device/v3/getdevice. Whether a device is a keypad — and which
-  // family it speaks — is decided by the pairing UI / pairer from its live
+  // family it speaks — is decided by the setup UI / pairer from its live
   // BLE advertisement (keypad_advert.h); the cloud only supplies identity
   // (MAC, name) and, later, the communication key.
   struct AccountDevice {
     std::string mac;          // hex, no separators: "B0E9FE612E75"
     std::string mac_pretty;   // "B0:E9:FE:61:2E:75"
     std::string name;         // user-set, e.g. "Keypad Vision 75"
+    std::string device_type;  // cloud SKU, e.g. "WoLock" / "WoLockPro"
   };
 
   // Authenticate against the SwitchBot account API. Captures the bearer
@@ -52,11 +53,11 @@ class CloudClient {
   bool list_devices(std::vector<AccountDevice> &out_devices,
                     std::string &error_out, bool force_refresh = false);
 
-  // Look up a specific keypad's communication key. `mac` may be in
-  // pretty (`B0:E9:FE:...`) or compact (`B0E9FE...`) form.
+  // Look up a device communication key. `mac` may be in pretty
+  // (`B0:E9:FE:...`) or compact (`B0E9FE...`) form.
   // `key_id_hex` receives the hex string (e.g. "88" or "C6"),
   // `key_bytes` receives the 16-byte AES key.
-  bool fetch_keypad_key(const std::string &mac, std::string &key_id_hex,
+  bool fetch_device_key(const std::string &mac, std::string &key_id_hex,
                         std::vector<uint8_t> &key_bytes,
                         std::string &error_out);
 

--- a/components/switchbot_keypad_bridge/keypad_advert.h
+++ b/components/switchbot_keypad_bridge/keypad_advert.h
@@ -25,7 +25,7 @@ namespace switchbot_keypad_bridge {
 // advertisement — never from any cloud field.
 enum class KeypadFamily : uint8_t { ORIGINAL, VISION };
 
-// Stable wire names for the family, used to carry it between the pairing UI
+// Stable wire names for the family, used to carry it between the setup UI
 // and the firmware. `keypad_family_from_str` falls back to ORIGINAL for any
 // unrecognised input.
 const char *keypad_family_str(KeypadFamily family);

--- a/components/switchbot_keypad_bridge/keypad_pairer.cpp
+++ b/components/switchbot_keypad_bridge/keypad_pairer.cpp
@@ -2,8 +2,8 @@
 
 #include <host/ble_gap.h>
 
-#include <cstdio>
 #include <cstring>
+#include <utility>
 
 #include "esphome/core/log.h"
 #include "aes_ctr.h"
@@ -17,11 +17,6 @@ namespace switchbot_keypad_bridge {
 namespace {
 
 const char *const TAG = "switchbot_keypad_bridge.pairer";
-
-// GATT UUIDs published by every SwitchBot lock / keypad.
-constexpr const char *SERVICE_UUID = "cba20d00-224d-11e6-9fb8-0002a5d5c51b";
-constexpr const char *RX_CHAR_UUID = "cba20002-224d-11e6-9fb8-0002a5d5c51b";
-constexpr const char *TX_CHAR_UUID = "cba20003-224d-11e6-9fb8-0002a5d5c51b";
 
 // Per-family pairing dialect: the BLE handshake constants that differ
 // between the Original and Vision keypad families.
@@ -46,9 +41,7 @@ constexpr uint8_t VISION_CAPABILITIES_PROBE[]= {0x0f, 0x53, 0x07, 0x03};
 constexpr uint8_t VISION_FINALIZE_TAIL[]     = {0x04, 0x04, 0x01, 0x05, 0x08, 0x09};
 
 // Doorbell-enable setting toggle (byte[4] = 0x02 enable / 0x01 disable),
-// captured from the official app. The app only exposes the toggle once a lock
-// is bound to the account, but the keypad firmware accepts the plain setting
-// write unconditionally. Vision-family only — Original/Touch have no doorbell.
+// captured from the official app. Vision-family only.
 constexpr uint8_t VISION_ENABLE_DOORBELL[]   = {0x0f, 0x52, 0x01, 0x09, 0x02, 0x01, 0x01};
 
 constexpr FamilyPreset ORIGINAL_PRESET = {
@@ -70,14 +63,6 @@ const FamilyPreset &preset_for(KeypadFamily f) {
   return f == KeypadFamily::VISION ? VISION_PRESET : ORIGINAL_PRESET;
 }
 
-// Friendly step labels — kept short so the UI's progress card stays tidy.
-// The wizard fetches these through step_count()/step_label() (via the
-// /api/pair response) and builds its stepper from them, so this list is
-// the single source of truth for count, order and wording.
-//
-// The first BASE_STEP_COUNT entries are common to every family; the trailing
-// "Enabling doorbell" step exists only on the Vision family (Original/Touch
-// keypads have no doorbell).
 constexpr const char *STEP_LABELS[] = {
     "Connecting to keypad",
     "Discovering services",
@@ -87,20 +72,12 @@ constexpr const char *STEP_LABELS[] = {
     "Writing shared key (2/2)",
     "Updating lock target",
     "Finalising",
-    "Force-enabling doorbell",  // Vision-only
+    "Force-enabling doorbell",
 };
-constexpr uint8_t BASE_STEP_COUNT   = 8;   // steps 0..7, every family
-constexpr uint8_t DOORBELL_STEP      = 8;   // index of the Vision-only step
-constexpr uint8_t VISION_STEP_COUNT = 9;   // base + doorbell
+constexpr uint8_t BASE_STEP_COUNT   = 8;
+constexpr uint8_t DOORBELL_STEP     = 8;
+constexpr uint8_t VISION_STEP_COUNT = 9;
 
-// Briefly scan and look up the advertising packet of the target MAC so
-// we can connect with the right address type. The keypad's first byte
-// (top 2 bits = 11) makes it a BLE "random static" address; without a
-// scan we'd have to guess between PUBLIC and RANDOM. Returns the
-// address with the discovered type on success, an empty address on
-// timeout. On success, `ident_out` carries the keypad model/family read
-// from the advertisement (pySwitchbot-style); `ident_out.is_keypad` is
-// false when the advert didn't match a known signature.
 NimBLEAddress discover_target(const std::string &mac_pretty, uint32_t timeout_ms,
                              KeypadIdent &ident_out) {
   NimBLEScan *scan = NimBLEDevice::getScan();
@@ -125,8 +102,6 @@ NimBLEAddress discover_target(const std::string &mac_pretty, uint32_t timeout_ms
 
 }  // namespace
 
-// ── Lifecycle ─────────────────────────────────────────────────────────────
-
 uint8_t KeypadPairer::step_count(KeypadFamily family) {
   return family == KeypadFamily::VISION ? VISION_STEP_COUNT : BASE_STEP_COUNT;
 }
@@ -136,123 +111,55 @@ const char *KeypadPairer::step_label(KeypadFamily family, uint8_t step) {
 }
 
 std::string KeypadPairer::start(Request req) {
-  {
-    std::lock_guard<std::mutex> lk(this->mu_);
-    if (this->status_.state == State::RUNNING) {
-      return "";  // refuse concurrent jobs
-    }
-  }
+  const uint8_t total = step_count(req.family);
+  return this->start_job_(
+      this, std::move(req), 'p', "kp-pair", total, STEP_LABELS[0],
+      "Could not start keypad-link task", TAG, "Keypad link", &this->task_handle_,
+      [this](Request &prepared) {
+        this->key_ = prepared.key;
+        this->key_id_ = static_cast<uint8_t>(prepared.key_id);
+        this->iv_received_ = false;
 
-  // Generate a job id — millis() is fine, monotonic enough for polling.
-  char job_buf[16];
-  std::snprintf(job_buf, sizeof(job_buf), "p-%lu",
-                static_cast<unsigned long>(esp_timer_get_time() / 1000));
-  std::string job_id = job_buf;
+        if (this->ack_sem_ == nullptr) {
+          this->ack_sem_ = xSemaphoreCreateBinary();
+        }
+        while (xSemaphoreTake(this->ack_sem_, 0) == pdTRUE) { /* drain */ }
 
-  // Move the request into a heap-allocated copy that the task takes
-  // ownership of.
-  auto *req_heap = new Request(std::move(req));
-
-  // Stash the things the notification callback needs right now —
-  // the request goes to the task that frees it.
-  this->key_      = req_heap->key;
-  this->key_id_   = static_cast<uint8_t>(req_heap->key_id);
-  this->iv_received_ = false;
-
-  // One-slot ACK semaphore (counting=1 with initial value 0).
-  if (this->ack_sem_ == nullptr) {
-    this->ack_sem_ = xSemaphoreCreateBinary();
-  }
-  while (xSemaphoreTake(this->ack_sem_, 0) == pdTRUE) { /* drain */ }
-
-  this->set_running_(step_count(req_heap->family), job_id);
-
-  // Spawn the task. The trampoline forwards to execute_() and frees the
-  // request when done.
-  struct TaskCtx {
-    KeypadPairer *self;
-    Request      *req;
-  };
-  auto *ctx = new TaskCtx{this, req_heap};
-
-  BaseType_t rc = xTaskCreatePinnedToCore(
-      [](void *raw) {
-        auto *c = static_cast<TaskCtx *>(raw);
-        c->self->execute_(*c->req);
-        delete c->req;
-        c->self->task_handle_ = nullptr;
-        delete c;
-        vTaskDelete(nullptr);
-      },
-      "kp-pair", 8192, ctx,
-      tskIDLE_PRIORITY + 2, &this->task_handle_,
-      // Pin to the BT task's core (typically 0) so the NimBLE callbacks
-      // and our central operations don't bounce across cores.
-      0);
-
-  if (rc != pdPASS) {
-    delete ctx;
-    delete req_heap;
-    this->set_failed_("Could not start pairing task");
-    return "";
-  }
-  return job_id;
+        this->status_keypad_mac_.clear();
+        this->status_family_ = KeypadFamily::ORIGINAL;
+      });
 }
 
 KeypadPairer::Status KeypadPairer::status() const {
   std::lock_guard<std::mutex> lk(this->mu_);
-  return this->status_;
-}
-
-// ── Status helpers ────────────────────────────────────────────────────────
-
-void KeypadPairer::set_running_(uint8_t total, const std::string &job_id) {
-  std::lock_guard<std::mutex> lk(this->mu_);
-  this->status_.state   = State::RUNNING;
-  this->status_.step    = 0;
-  this->status_.total   = total;
-  this->status_.message = STEP_LABELS[0];
-  this->status_.error.clear();
-  this->status_.job_id  = job_id;
+  Status out;
+  this->copy_status_base_(out);
+  out.keypad_mac = this->status_keypad_mac_;
+  out.family = this->status_family_;
+  return out;
 }
 
 void KeypadPairer::set_step_(uint8_t step, const char *msg) {
-  std::lock_guard<std::mutex> lk(this->mu_);
-  ESP_LOGI(TAG, "Step %u/%u: %s", static_cast<unsigned>(step + 1),
-           static_cast<unsigned>(this->status_.total), msg);
-  this->status_.step    = step;
-  this->status_.message = msg;
+  this->mark_step_(step, msg, TAG);
 }
 
 void KeypadPairer::set_success_(const std::string &keypad_mac,
                                 KeypadFamily family) {
-  ESP_LOGI(TAG, "Pairing successful");
+  ESP_LOGI(TAG, "Keypad link successful");
   std::lock_guard<std::mutex> lk(this->mu_);
-  this->status_.state      = State::SUCCESS;
-  this->status_.step       = this->status_.total;
-  this->status_.message    = "Pairing complete";
+  this->status_.state = State::SUCCESS;
+  this->status_.step = this->status_.total;
+  this->status_.message = "Keypad linked";
   this->status_.error.clear();
-  this->status_.keypad_mac = keypad_mac;
-  this->status_.family     = family;
+  this->status_keypad_mac_ = keypad_mac;
+  this->status_family_ = family;
 }
 
 void KeypadPairer::set_failed_(const std::string &err) {
-  ESP_LOGW(TAG, "Pairing failed: %s", err.c_str());
-  std::lock_guard<std::mutex> lk(this->mu_);
-  this->status_.state   = State::FAILED;
-  this->status_.error   = err;
-  this->status_.message = err;
+  this->mark_failed_(err, TAG, "Keypad link");
 }
 
-// ── BLE notification sink ─────────────────────────────────────────────────
-
 void KeypadPairer::on_notify_(const uint8_t *data, size_t length) {
-  // This runs on the NimBLE host task — a task context, not an ISR — so
-  // the plain xSemaphoreGive() is the correct primitive here.
-  //
-  // The session-IV reply is the only notification with a payload we
-  // actually need to inspect. Everything else just bumps the ACK
-  // semaphore so send_command_() can move on.
   if (length == 20 && data[0] == 0x01 && data[1] == 0x00) {
     std::memcpy(this->iv_.data(), data + 4, 16);
     this->iv_received_.store(true);
@@ -262,14 +169,8 @@ void KeypadPairer::on_notify_(const uint8_t *data, size_t length) {
   }
 }
 
-// ── Encrypted send ────────────────────────────────────────────────────────
-
 bool KeypadPairer::send_command_(NimBLERemoteCharacteristic *rx,
                                  const uint8_t *plaintext, size_t plaintext_len) {
-  // Encrypted frame layout (same as the existing keypad command path):
-  //   [0x57][key_id][IV[0]][IV[1]][AES-CTR(K14, IV, plaintext)]
-  // The keypad's K14 only lives for the duration of one pairing run, so it
-  // is imported fresh for each frame and destroyed right after.
   std::vector<uint8_t> frame(4 + plaintext_len);
   frame[0] = 0x57;
   frame[1] = this->key_id_;
@@ -280,26 +181,15 @@ bool KeypadPairer::send_command_(NimBLERemoteCharacteristic *rx,
     return false;
   }
 
-  // Drain any stale ACK before issuing the write.
   while (xSemaphoreTake(this->ack_sem_, 0) == pdTRUE) { /* drain */ }
   if (!rx->writeValue(frame.data(), frame.size(), /*response=*/true)) {
     return false;
   }
-  // Wait briefly for the ACK notification. We tolerate a missing ACK on most
-  // steps — the keypad doesn't always respond to the cosmetic commands.
   xSemaphoreTake(this->ack_sem_, pdMS_TO_TICKS(800));
   return true;
 }
 
-// ── Task body ─────────────────────────────────────────────────────────────
-
 void KeypadPairer::execute_(Request &req) {
-  // Step 0: discover the target via an active scan, then connect with
-  // the correct address type. Without the scan we'd have to guess
-  // between PUBLIC and RANDOM, and the BLE spec uses the top bits of
-  // the MAC to encode the type — but the cloud only gives us the bare
-  // bytes, not the type. Scanning is also the natural check that the
-  // keypad is in range right now.
   this->set_step_(0, STEP_LABELS[0]);
   KeypadIdent ident;
   NimBLEAddress target = discover_target(req.keypad_mac, 6000, ident);
@@ -308,61 +198,37 @@ void KeypadPairer::execute_(Request &req) {
     return;
   }
 
-  // The pairing dialect follows the family already identified by the UI (from
-  // the BLE service-data signature, cached by MAC). We do NOT re-derive it from
-  // this scan: the Keypad Vision doesn't carry its signature on every
-  // advertisement, so discover_target may legitimately fail to classify it even
-  // though it is a keypad. The scan above was only needed for the address type.
   const KeypadFamily family = req.family;
-  ESP_LOGI(TAG, "Pairing keypad as %s family", keypad_family_str(family));
+  ESP_LOGI(TAG, "Linking keypad as %s family", keypad_family_str(family));
   const FamilyPreset &preset = preset_for(family);
 
-  // The keypad might currently be connected to our peripheral (server) role —
-  // it sends IV requests to us as a SwitchBot Lock emulation. The BLE spec
-  // allows only one ACL link between two peers, so we must terminate that
-  // link before the central connect, otherwise connect() will always fail.
   {
     struct ble_gap_conn_desc desc{};
     if (ble_gap_conn_find_by_addr(target.getBase(), &desc) == 0) {
-      ESP_LOGI(TAG, "Keypad still connected as peripheral (h=%u) — terminating before pair",
+      ESP_LOGI(TAG, "Keypad still connected as peripheral (h=%u), terminating before pair",
                desc.conn_handle);
       ble_gap_terminate(desc.conn_handle, BLE_ERR_REM_USER_CONN_TERM);
       vTaskDelay(pdMS_TO_TICKS(600));
     }
   }
 
-  NimBLEClient *client = NimBLEDevice::createClient();
-  client->setConnectTimeout(10000);  // ms (NimBLE-cpp 2.x uses ms, not seconds)
-  if (!client->connect(target)) {
-    NimBLEDevice::deleteClient(client);
-    this->set_failed_("Could not connect to the keypad. Keep it within 2 m and retry.");
+  SwitchbotGattConnection gatt;
+  std::string error;
+  if (!connect_switchbot_service(target, 10000, "keypad", gatt, error)) {
+    this->set_failed_(error);
     return;
   }
+  NimBLEClient *client = gatt.client;
+  NimBLERemoteCharacteristic *rx = gatt.rx;
+  NimBLERemoteCharacteristic *tx = gatt.tx;
 
-  // Step 1: discover service + characteristics.
   this->set_step_(1, STEP_LABELS[1]);
-  NimBLERemoteService *svc = client->getService(NimBLEUUID(SERVICE_UUID));
-  NimBLERemoteCharacteristic *rx = nullptr;
-  NimBLERemoteCharacteristic *tx = nullptr;
-  if (svc != nullptr) {
-    rx = svc->getCharacteristic(NimBLEUUID(RX_CHAR_UUID));
-    tx = svc->getCharacteristic(NimBLEUUID(TX_CHAR_UUID));
-  }
-  if (rx == nullptr || tx == nullptr) {
-    client->disconnect();
-    NimBLEDevice::deleteClient(client);
-    this->set_failed_("Keypad does not expose the SwitchBot GATT service.");
-    return;
-  }
-
-  // Subscribe to TX notifications.
   tx->subscribe(true,
                 [this](NimBLERemoteCharacteristic *, uint8_t *data,
                        size_t length, bool /*is_notify*/) {
                   this->on_notify_(data, length);
                 });
 
-  // Step 2: IV request.
   this->set_step_(2, STEP_LABELS[2]);
   while (xSemaphoreTake(this->ack_sem_, 0) == pdTRUE) { /* drain */ }
   uint8_t iv_req[8] = {0x57, 0x00, 0x00, 0x00, 0x0F, 0x21, 0x03,
@@ -373,7 +239,6 @@ void KeypadPairer::execute_(Request &req) {
     this->set_failed_("Could not request session IV from keypad.");
     return;
   }
-  // Give the keypad up to 3 s to reply with the 20-byte IV frame.
   for (int i = 0; i < 6 && !this->iv_received_.load(); ++i) {
     xSemaphoreTake(this->ack_sem_, pdMS_TO_TICKS(500));
   }
@@ -384,8 +249,6 @@ void KeypadPairer::execute_(Request &req) {
     return;
   }
 
-  // Steps 3..7: the pairing commands proper. Helper that reports a step,
-  // sends a plaintext command, and surfaces a friendly error on failure.
   auto run_step = [&](uint8_t step, const uint8_t *pt, size_t pt_len,
                       const char *err_msg) -> bool {
     this->set_step_(step, STEP_LABELS[step]);
@@ -398,9 +261,6 @@ void KeypadPairer::execute_(Request &req) {
     return true;
   };
 
-  // Step 3: open lock slot. Original keypads send the enter_pairing
-  // command directly; Vision keypads additionally precede it with a
-  // capabilities probe.
   this->set_step_(3, STEP_LABELS[3]);
   if (!this->send_command_(rx, preset.enter_pairing, preset.enter_pairing_len)) {
     client->disconnect();
@@ -408,16 +268,11 @@ void KeypadPairer::execute_(Request &req) {
     this->set_failed_("enter_pairing rejected.");
     return;
   }
-  // Best-effort pair of frames: the capabilities probe is informational and
-  // the prep preamble is tolerated missing by every keypad we've captured.
   if (preset.capabilities_probe != nullptr) {
     this->send_command_(rx, preset.capabilities_probe, preset.capabilities_probe_len);
   }
   uint8_t prep[] = {0x06, 0x03};
   this->send_command_(rx, prep, sizeof(prep));
-  // slot_init is NOT best-effort: it opens the slot the shared key is written
-  // into on steps 4-5. Carrying on after a failed write would report SUCCESS
-  // for a keypad that never works.
   uint8_t slot_init[] = {0x0F, 0x20, 0x03, preset.shared_slot, preset.slot_init_nonce};
   if (!this->send_command_(rx, slot_init, sizeof(slot_init))) {
     client->disconnect();
@@ -426,27 +281,23 @@ void KeypadPairer::execute_(Request &req) {
     return;
   }
 
-  // Step 4: shared_key chunk 1.
   uint8_t tok1[5 + 8];
   tok1[0] = 0x0F; tok1[1] = 0x20; tok1[2] = 0x04;
   tok1[3] = preset.shared_slot; tok1[4] = 0x00;
   std::memcpy(tok1 + 5, req.shared_token.data(), 8);
   if (!run_step(4, tok1, sizeof(tok1), "Could not write shared_key (1/2).")) return;
 
-  // Step 5: shared_key chunk 2.
   uint8_t tok2[5 + 8];
   tok2[0] = 0x0F; tok2[1] = 0x20; tok2[2] = 0x04;
   tok2[3] = preset.shared_slot; tok2[4] = 0x01;
   std::memcpy(tok2 + 5, req.shared_token.data() + 8, 8);
   if (!run_step(5, tok2, sizeof(tok2), "Could not write shared_key (2/2).")) return;
 
-  // Step 6: change keypad's lock target to our ESP MAC.
   uint8_t mac_payload[3 + 6];
   mac_payload[0] = 0x06; mac_payload[1] = 0x01; mac_payload[2] = preset.shared_slot;
   std::memcpy(mac_payload + 3, req.esp_mac.data(), 6);
   if (!run_step(6, mac_payload, sizeof(mac_payload), "Could not update target lock MAC.")) return;
 
-  // Step 7: finalize.
   this->set_step_(7, STEP_LABELS[7]);
   {
     std::vector<uint8_t> fin = {0x0f, 0x52, 0x02, 0x02, 0x10, 0xFF, 0x05, 0x06};
@@ -457,18 +308,11 @@ void KeypadPairer::execute_(Request &req) {
   uint8_t finalize2[] = {0x0f, 0x53, 0x01, 0x06};
   this->send_command_(rx, finalize2, sizeof(finalize2));
 
-  // Step 8 (Vision only): enable the doorbell while we still hold an
-  // authenticated session. The slot is written and finalised, so this is the
-  // last safe moment to push a setting before disconnecting. Surfaced as its
-  // own step — the user sees it happen instead of it being a silent extra.
-  // Still best-effort: the keypad is already paired and usable, so a missing
-  // ACK here must not fail the whole job.
   if (preset.enable_doorbell != nullptr) {
     this->set_step_(DOORBELL_STEP, STEP_LABELS[DOORBELL_STEP]);
     this->send_command_(rx, preset.enable_doorbell, preset.enable_doorbell_len);
   }
 
-  // Cleanup.
   client->disconnect();
   NimBLEDevice::deleteClient(client);
 

--- a/components/switchbot_keypad_bridge/keypad_pairer.h
+++ b/components/switchbot_keypad_bridge/keypad_pairer.h
@@ -23,33 +23,22 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
-#include <mutex>
 #include <string>
 #include <vector>
 
+#include "background_job.h"
 #include "keypad_advert.h"
 
 namespace esphome {
 namespace switchbot_keypad_bridge {
 
-class KeypadPairer {
+class KeypadPairer : private BackgroundBleJob {
  public:
-  enum class State : uint8_t {
-    IDLE,
-    RUNNING,
-    SUCCESS,
-    FAILED,
-  };
+  using State = BackgroundBleJob::State;
 
   // Snapshot of the pairer's progress, safe to copy across threads.
-  struct Status {
-    State       state{State::IDLE};
-    uint8_t     step{0};       // 0-based index of the step currently in flight
-    uint8_t     total{0};      // total number of steps; 0 before start
-    std::string message;       // human-readable status of the current step
-    std::string error;         // populated when state == FAILED
-    std::string job_id;        // matches the value returned by start()
-    // Identity of the keypad just paired, valid only when state == SUCCESS.
+  struct Status : BackgroundBleJob::Status {
+    // Identity of the keypad just linked, valid only when state == SUCCESS.
     // The family comes from the live advertisement read during discovery.
     std::string keypad_mac;    // pretty form, e.g. "B0:E9:FE:..."
     KeypadFamily family{KeypadFamily::ORIGINAL};
@@ -83,12 +72,16 @@ class KeypadPairer {
   // Atomic snapshot of progress. Suitable for polling from any thread.
   Status status() const;
 
+  // Cheap state-only read (no string copies) — for per-loop polling.
+  State state() const { return BackgroundBleJob::state(); }
+
  private:
+  friend class BackgroundBleJob;
+
   void execute_(Request &req);
 
   // Step helpers (push step number + message, log, return immediately).
   void set_step_(uint8_t step, const char *msg);
-  void set_running_(uint8_t total, const std::string &job_id);
   void set_success_(const std::string &keypad_mac, KeypadFamily family);
   void set_failed_(const std::string &err);
 
@@ -102,9 +95,9 @@ class KeypadPairer {
   bool send_command_(NimBLERemoteCharacteristic *rx,
                      const uint8_t *plaintext, size_t plaintext_len);
 
-  // ----- Shared state (read by status(), written by the task) -----
-  mutable std::mutex   mu_;
-  Status               status_{};
+  // ----- Success payload (read by status(), written by the task) -----
+  std::string          status_keypad_mac_;
+  KeypadFamily         status_family_{KeypadFamily::ORIGINAL};
 
   // ----- Task / sync primitives -----
   TaskHandle_t         task_handle_{nullptr};

--- a/components/switchbot_keypad_bridge/lock_advert.cpp
+++ b/components/switchbot_keypad_bridge/lock_advert.cpp
@@ -1,0 +1,39 @@
+#include "lock_advert.h"
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+namespace {
+
+int valid_percent(uint8_t raw) {
+  const int value = raw & 0x7F;
+  return value <= 100 ? value : -1;
+}
+
+}  // namespace
+
+int parse_lock_battery(PhysicalLockModel model,
+                       const uint8_t *service_data, size_t service_len,
+                       const uint8_t *manufacturer_payload,
+                       size_t manufacturer_len) {
+  switch (model) {
+    case PhysicalLockModel::LOCK:
+    case PhysicalLockModel::LOCK_LITE:
+    case PhysicalLockModel::LOCK_VISION:
+      if (service_data == nullptr || service_len < 3) return -1;
+      return valid_percent(service_data[2]);
+
+    case PhysicalLockModel::LOCK_PRO:
+    case PhysicalLockModel::LOCK_PRO_WIFI:
+    case PhysicalLockModel::LOCK_ULTRA:
+    case PhysicalLockModel::LOCK_VISION_PRO:
+      if (manufacturer_payload == nullptr || manufacturer_len < 10) return -1;
+      return valid_percent(manufacturer_payload[9]);
+
+    default:
+      return -1;
+  }
+}
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/lock_advert.h
+++ b/components/switchbot_keypad_bridge/lock_advert.h
@@ -1,0 +1,22 @@
+#pragma once
+
+// SwitchBot physical lock battery extraction from BLE advertisements.
+
+#include <cstddef>
+#include <cstdint>
+
+#include "physical_lock.h"
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+// `manufacturer_payload` is the SwitchBot manufacturer payload after the
+// 2-byte company id (0x0969). Returns -1 when the advert does not carry a
+// battery field for the supplied model.
+int parse_lock_battery(PhysicalLockModel model,
+                       const uint8_t *service_data, size_t service_len,
+                       const uint8_t *manufacturer_payload,
+                       size_t manufacturer_len);
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/lock_linker.cpp
+++ b/components/switchbot_keypad_bridge/lock_linker.cpp
@@ -1,0 +1,207 @@
+#include "lock_linker.h"
+
+#include <utility>
+#include <vector>
+
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+namespace {
+
+const char *const TAG = "switchbot_keypad_bridge.linker";
+
+// Friendly step labels — kept short so the UI's progress card stays tidy.
+enum LockLinkStep : uint8_t {
+  STEP_CONNECT = 0,
+  STEP_DISCOVER,
+  STEP_SESSION,
+  STEP_OPEN_SLOT,
+  STEP_WRITE_KEY_1,
+  STEP_WRITE_KEY_2,
+  STEP_VERIFY_SHARED_KEY,
+};
+
+constexpr const char *STEP_LABELS[] = {
+    "Connecting to lock",
+    "Discovering services",
+    "Negotiating provisioning session",
+    "Opening lock slot",
+    "Writing shared key (1/2)",
+    "Writing shared key (2/2)",
+    "Verifying shared key",
+};
+constexpr uint8_t STEP_COUNT = sizeof(STEP_LABELS) / sizeof(STEP_LABELS[0]);
+
+constexpr uint8_t SHARED_SLOT_ORIGINAL = 0x88;
+constexpr uint8_t SHARED_SLOT_VISION   = 0xC6;
+
+uint8_t slot_nonce(uint8_t slot_id) {
+  return slot_id == SHARED_SLOT_VISION ? 0x80 : 0x69;
+}
+
+std::vector<std::vector<uint8_t>> make_provision_commands(
+    uint8_t slot_id, const std::array<uint8_t, 16> &shared_key) {
+  return {
+      {0x0F, 0x20, 0x09, slot_id},
+      {0x0F, 0x20, 0x03, slot_id, slot_nonce(slot_id)},
+      {0x0F, 0x20, 0x04, slot_id, 0x00,
+       shared_key[0], shared_key[1], shared_key[2], shared_key[3],
+       shared_key[4], shared_key[5], shared_key[6], shared_key[7]},
+      {0x0F, 0x20, 0x04, slot_id, 0x01,
+       shared_key[8], shared_key[9], shared_key[10], shared_key[11],
+       shared_key[12], shared_key[13], shared_key[14], shared_key[15]},
+  };
+}
+
+bool provision_responses_plausible(
+    uint8_t slot_id, const std::vector<std::vector<uint8_t>> &responses) {
+  if (responses.size() != 4) {
+    return false;
+  }
+  if (!responses[0].empty() &&
+      !(responses[0].size() == 1 && responses[0][0] == slot_id)) {
+    return false;
+  }
+  if (responses[1].size() != 2 || responses[1][0] != slot_id ||
+      responses[1][1] != slot_nonce(slot_id)) {
+    return false;
+  }
+  return responses[2].size() == 1 && responses[2][0] == slot_id &&
+         responses[3].size() == 1 && responses[3][0] == slot_id;
+}
+
+}  // namespace
+
+uint8_t LockLinker::step_count() { return STEP_COUNT; }
+
+const char *LockLinker::step_label(uint8_t step) {
+  return step < STEP_COUNT ? STEP_LABELS[step] : "";
+}
+
+std::string LockLinker::start(Request req) {
+  return this->start_job_(this, std::move(req), 'l', "lock-link", STEP_COUNT,
+                          STEP_LABELS[0], "Could not start lock-link task",
+                          TAG, "Lock link", nullptr, [this](Request &) {
+                            this->status_name_.clear();
+                            this->status_mac_.clear();
+                            this->status_model_ = PhysicalLockModel::UNKNOWN;
+                            this->status_slot_id_ = 0;
+                          });
+}
+
+LockLinker::Status LockLinker::status() const {
+  std::lock_guard<std::mutex> lk(this->mu_);
+  Status out;
+  this->copy_status_base_(out);
+  out.name = this->status_name_;
+  out.mac = this->status_mac_;
+  out.model = this->status_model_;
+  out.slot_id = this->status_slot_id_;
+  return out;
+}
+
+// ── Status helpers ────────────────────────────────────────────────────────
+
+void LockLinker::set_step_(uint8_t step) {
+  if (step >= STEP_COUNT) return;
+  this->mark_step_(step, STEP_LABELS[step], TAG);
+}
+
+void LockLinker::set_success_(const Request &req) {
+  ESP_LOGI(TAG, "Shared key verified for '%s' (%s, slot=0x%02X)",
+           req.name.c_str(), req.mac.c_str(), this->status_slot_id_);
+  std::lock_guard<std::mutex> lk(this->mu_);
+  this->status_.state   = State::SUCCESS;
+  this->status_.step    = this->status_.total;
+  this->status_.message = "Lock linked";
+  this->status_.error.clear();
+  this->status_name_ = req.name;
+  this->status_mac_ = req.mac;
+  this->status_model_ = req.model;
+}
+
+void LockLinker::set_failed_(const std::string &err) {
+  this->mark_failed_(err, TAG, "Lock link");
+}
+
+// ── Task body ─────────────────────────────────────────────────────────────
+
+void LockLinker::execute_(Request &req) {
+  std::string err;
+  const uint8_t slot = req.shared_slot_id != 0 ? req.shared_slot_id : SHARED_SLOT_ORIGINAL;
+
+  PhysicalLockClient::Config provisioning_cfg;
+  provisioning_cfg.mac    = req.mac;
+  provisioning_cfg.model  = req.model;
+  provisioning_cfg.key_id = req.lock_key_id;
+  provisioning_cfg.key    = req.lock_key;
+
+  PhysicalLockClient::Config shared_cfg;
+  shared_cfg.mac    = req.mac;
+  shared_cfg.model  = req.model;
+  shared_cfg.key_id = slot;
+  shared_cfg.key    = req.shared_key;
+
+  auto provision_phase = [this](PhysicalLockClient::Phase phase) {
+    switch (phase) {
+      case PhysicalLockClient::Phase::CONNECT:
+        this->set_step_(STEP_CONNECT);
+        break;
+      case PhysicalLockClient::Phase::DISCOVER:
+        this->set_step_(STEP_DISCOVER);
+        break;
+      case PhysicalLockClient::Phase::SESSION:
+        this->set_step_(STEP_SESSION);
+        break;
+      case PhysicalLockClient::Phase::SCAN:
+      case PhysicalLockClient::Phase::COMMAND:
+        break;
+    }
+  };
+  auto provision_command = [this](size_t command_index) {
+    if (command_index < 2) {
+      this->set_step_(STEP_OPEN_SLOT);
+    } else if (command_index == 2) {
+      this->set_step_(STEP_WRITE_KEY_1);
+    } else if (command_index == 3) {
+      this->set_step_(STEP_WRITE_KEY_2);
+    }
+  };
+  auto verify_phase = [this](PhysicalLockClient::Phase phase) {
+    switch (phase) {
+      case PhysicalLockClient::Phase::COMMAND:
+        this->set_step_(STEP_VERIFY_SHARED_KEY);
+        break;
+      case PhysicalLockClient::Phase::SCAN:
+      case PhysicalLockClient::Phase::CONNECT:
+      case PhysicalLockClient::Phase::DISCOVER:
+      case PhysicalLockClient::Phase::SESSION:
+        break;
+    }
+  };
+
+  std::vector<std::vector<uint8_t>> provision_responses;
+  const std::vector<std::vector<uint8_t>> provision_commands =
+      make_provision_commands(slot, req.shared_key);
+  if (!this->client_.provision_and_verify_shared_key(
+          provisioning_cfg, provision_commands, provision_responses,
+          shared_cfg, err, provision_phase, provision_command, verify_phase)) {
+    this->set_failed_("Could not link the lock shared key: " + err);
+    return;
+  }
+  if (!provision_responses_plausible(slot, provision_responses)) {
+    this->set_failed_("The lock returned an unexpected shared-key provisioning response.");
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lk(this->mu_);
+    this->status_slot_id_ = slot;
+  }
+  this->set_success_(req);
+}
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/lock_linker.h
+++ b/components/switchbot_keypad_bridge/lock_linker.h
@@ -1,0 +1,94 @@
+#pragma once
+
+// Background task that provisions the bridge's shared keypad/lock key into a
+// physical SwitchBot Lock, then verifies that the shared slot answers.
+//
+// User-facing progress mirrors the keypad pairer style: transport setup first,
+// then grouped pairing operations:
+//   1. Connect to the lock
+//   2. Discover the SwitchBot GATT service
+//   3. Negotiate the provisioning session
+//   4. Create/open the shared slot
+//   5. Write the first shared-key half
+//   6. Write the second shared-key half
+//   7. Verify the shared slot with a lock-info command
+//
+// Spawned once per link attempt; the HTTP handler polls `status()` from the
+// UI's `/api/lock/link/status`, and the bridge's loop() fires the linked
+// callback from the SUCCESS snapshot (browser-independent).
+
+#include <array>
+#include <cstdint>
+#include <mutex>
+#include <string>
+
+#include "background_job.h"
+#include "physical_lock.h"
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+class LockLinker : private BackgroundBleJob {
+ public:
+  using State = BackgroundBleJob::State;
+
+  // Snapshot of the linker's progress, safe to copy across threads.
+  struct Status : BackgroundBleJob::Status {
+    // Identity of the lock just verified, valid only when state == SUCCESS.
+    // Carries everything the bridge persists, so the linked callback can be
+    // fired from this snapshot alone.
+    std::string name;
+    std::string mac;           // pretty form, e.g. "B0:E9:FE:..."
+    PhysicalLockModel model{PhysicalLockModel::UNKNOWN};
+    uint8_t slot_id{0};
+  };
+
+  // Arguments for a single link attempt. The lock cloud credential is used
+  // only as a bootstrap channel to write the bridge's shared key into the
+  // lock. Runtime relay persists and uses only shared_key/shared_slot_id.
+  struct Request {
+    std::string name;
+    std::string mac;           // pretty form, e.g. "B0:E9:FE:..."
+    PhysicalLockModel model{PhysicalLockModel::UNKNOWN};
+    std::array<uint8_t, 16> shared_key{};
+    uint8_t shared_slot_id{0};
+    uint8_t lock_key_id{0};
+    std::array<uint8_t, 16> lock_key{};
+  };
+
+  // Spawns the link task and returns a job id. If a job is already running
+  // this returns an empty string and leaves the current job untouched — only
+  // one link attempt can be in flight at a time.
+  std::string start(Request req);
+
+  // The user-facing label of each step, in order. The wizard builds its
+  // progress stepper from these (returned by /api/lock/link), so the linker
+  // is the single source of truth for step count, order and wording.
+  static uint8_t step_count();
+  static const char *step_label(uint8_t step);
+
+  // Atomic snapshot of progress. Suitable for polling from any thread.
+  Status status() const;
+
+  // Cheap state-only read (no string copies) — for per-loop polling.
+  State state() const { return BackgroundBleJob::state(); }
+
+ private:
+  friend class BackgroundBleJob;
+
+  void execute_(Request &req);
+
+  void set_step_(uint8_t step);
+  void set_success_(const Request &req);
+  void set_failed_(const std::string &err);
+
+  std::string status_name_;
+  std::string status_mac_;
+  PhysicalLockModel status_model_{PhysicalLockModel::UNKNOWN};
+  uint8_t status_slot_id_{0};
+
+  PhysicalLockClient client_{};
+};
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/lock_protocol.h
+++ b/components/switchbot_keypad_bridge/lock_protocol.h
@@ -26,7 +26,8 @@ enum class UnlockMethod : uint8_t {
 const char *unlock_method_name(UnlockMethod method);
 
 // The command a decrypted keypad frame represents. UNKNOWN means the bytes
-// matched no known frame — the caller should ACK and otherwise ignore it.
+// matched no known frame; the bridge may still relay the raw plaintext to a
+// linked physical lock.
 enum class CommandType : uint8_t {
   UNKNOWN,
   LOCK,

--- a/components/switchbot_keypad_bridge/lock_session.cpp
+++ b/components/switchbot_keypad_bridge/lock_session.cpp
@@ -18,7 +18,8 @@ const char *const TAG = "switchbot_keypad_bridge.session";
 // Encrypted protocol framing.
 constexpr uint8_t PROTOCOL_MAGIC = 0x57;
 
-// Session IV negotiation: first frame received after connect.
+// Session IV negotiation. Most keypads send this after connect; some reconnect
+// and continue with the IV they already have.
 // Shape: 57 00 00 00 0F 21 03 <key_id>
 constexpr size_t SESSION_IV_REQ_MIN = 8;
 
@@ -29,7 +30,14 @@ constexpr size_t IV_RESPONSE_HEADER = 4;  // iv_response_ prefix before the IV b
 
 void LockSession::reset() {
   this->iv_established_ = false;
+  this->plaintext_size_ = 0;
   this->clear_replay_history_();
+}
+
+void LockSession::reset_transport() {
+  this->plaintext_size_ = 0;
+  this->header_ = FrameHeader{};
+  this->command_ = DecodedCommand{};
 }
 
 LockSession::Action LockSession::process_frame(const std::string &frame) {
@@ -67,11 +75,11 @@ LockSession::Action LockSession::process_frame(const std::string &frame) {
     return Action::NONE;
   }
 
-  // Refuse encrypted frames before the IV handshake completed in this session.
-  // A captured ciphertext from a previous connection would otherwise decrypt
-  // against the wrong (or stale) IV and ride on whatever lock state is set.
+  // Refuse encrypted frames before any IV has been negotiated for this key.
+  // BLE reconnects may preserve the logical session, but a fresh boot/reset
+  // must not decrypt against a zero or unrelated IV.
   if (!this->iv_established_) {
-    ESP_LOGW(TAG, "Dropping encrypted frame: no IV negotiated in this session");
+    ESP_LOGW(TAG, "Dropping encrypted frame: no IV negotiated");
     return Action::NONE;
   }
 
@@ -102,6 +110,8 @@ LockSession::Action LockSession::process_frame(const std::string &frame) {
   if (!this->xcrypt_(ciphertext, ct_len, plaintext)) {
     return Action::NONE;  // error already logged
   }
+  std::memcpy(this->plaintext_.data(), plaintext, ct_len);
+  this->plaintext_size_ = ct_len;
 
   ESP_LOGD(TAG, "RX %s", format_hex_pretty(plaintext, ct_len).c_str());
 

--- a/components/switchbot_keypad_bridge/lock_session.cpp
+++ b/components/switchbot_keypad_bridge/lock_session.cpp
@@ -23,24 +23,28 @@ constexpr uint8_t PROTOCOL_MAGIC = 0x57;
 // Shape: 57 00 00 00 0F 21 03 <key_id>
 constexpr size_t SESSION_IV_REQ_MIN = 8;
 
-constexpr size_t AES_IV_SIZE = 16;
 constexpr size_t IV_RESPONSE_HEADER = 4;  // iv_response_ prefix before the IV bytes
 
 }  // namespace
 
 void LockSession::reset() {
-  this->iv_established_ = false;
-  this->plaintext_size_ = 0;
-  this->clear_replay_history_();
+  this->active_ = CryptoContext{};
+  this->pending_ = CryptoContext{};
+  this->reset_transport();
 }
 
 void LockSession::reset_transport() {
   this->plaintext_size_ = 0;
   this->header_ = FrameHeader{};
   this->command_ = DecodedCommand{};
+  this->response_iv_valid_ = false;
 }
 
 LockSession::Action LockSession::process_frame(const std::string &frame) {
+  // Never expose stale decoded bytes or a stale response IV after a dropped
+  // frame. The bridge may relay plaintext asynchronously after COMMAND.
+  this->reset_transport();
+
   ESP_LOGV(TAG, "RX WIRE %zu bytes: %s", frame.size(),
            format_hex_pretty(reinterpret_cast<const uint8_t *>(frame.data()), frame.size()).c_str());
 
@@ -54,10 +58,9 @@ LockSession::Action LockSession::process_frame(const std::string &frame) {
       this->slot_id_ = requested_slot;
     }
     ESP_LOGD(TAG, "IV request");
-    this->rotate_iv_();
-    // A new IV invalidates any ciphertext sniffed under the previous one.
-    this->clear_replay_history_();
-    this->iv_established_ = true;
+    // Do not overwrite active_ yet. Vision-family keypads can send a delayed
+    // state poll from the previous generation after requesting the next IV.
+    this->rotate_pending_iv_();
     return Action::SEND_IV;
   }
 
@@ -76,21 +79,23 @@ LockSession::Action LockSession::process_frame(const std::string &frame) {
   }
 
   // Refuse encrypted frames before any IV has been negotiated for this key.
-  // BLE reconnects may preserve the logical session, but a fresh boot/reset
-  // must not decrypt against a zero or unrelated IV.
-  if (!this->iv_established_) {
+  // BLE reconnects may preserve active_, but a fresh boot/reset must not
+  // decrypt against a zero or unrelated IV.
+  if (!this->active_.valid && !this->pending_.valid) {
     ESP_LOGW(TAG, "Dropping encrypted frame: no IV negotiated");
     return Action::NONE;
   }
 
-  // The protocol echoes IV[0..1] back as the seq_a/seq_b header bytes.
-  // Reject anything that does not match the IV we just issued — this blocks
-  // cross-session replay of captured ciphertexts.
-  if (this->header_.seq_a != this->iv_response_[IV_RESPONSE_HEADER] ||
-      this->header_.seq_b != this->iv_response_[IV_RESPONSE_HEADER + 1]) {
+  // The protocol echoes IV[0..1] as seq_a/seq_b. Prefer pending_ when the
+  // keypad has switched; otherwise retain active_ just long enough to finish
+  // an in-flight poll. rotate_pending_iv_() guarantees their seq pairs differ.
+  const bool uses_pending = this->seq_matches_(this->pending_, this->header_);
+  const bool uses_active = this->seq_matches_(this->active_, this->header_);
+  if (!uses_pending && !uses_active) {
     ESP_LOGW(TAG, "Dropping frame: seq_a/seq_b mismatch (cross-session replay?)");
     return Action::NONE;
   }
+  CryptoContext &context = uses_pending ? this->pending_ : this->active_;
 
   const size_t ct_len = frame.size() - HEADER_LEN;
   if (ct_len > MAX_PAYLOAD) {
@@ -104,21 +109,31 @@ LockSession::Action LockSession::process_frame(const std::string &frame) {
   // fixed session IV, identical plaintexts produce identical ciphertexts.
   // We only flag duplicates that decode to a side-effecting command — state
   // polls are idempotent and a legitimate keypad emits them repeatedly.
-  const bool ciphertext_seen = this->is_replayed_ciphertext_(ciphertext, ct_len);
+  const bool ciphertext_seen =
+      this->is_replayed_ciphertext_(context, ciphertext, ct_len);
 
   uint8_t plaintext[MAX_PAYLOAD];
-  if (!this->xcrypt_(ciphertext, ct_len, plaintext)) {
+  if (!this->xcrypt_(context.iv, ciphertext, ct_len, plaintext)) {
     return Action::NONE;  // error already logged
   }
-  std::memcpy(this->plaintext_.data(), plaintext, ct_len);
-  this->plaintext_size_ = ct_len;
 
   ESP_LOGD(TAG, "RX %s", format_hex_pretty(plaintext, ct_len).c_str());
 
   this->command_ = decode_lock_command(plaintext, ct_len);
+
+  // Once a new IV has been advertised, the superseded generation is accepted
+  // only for an idempotent state poll that was already in flight. In
+  // particular, never let a delayed/captured lock or unlock cross the IV
+  // boundary even if its ciphertext was not present in the small replay ring.
+  if (!uses_pending && this->pending_.valid &&
+      this->command_.type != CommandType::STATE_POLL) {
+    ESP_LOGW(TAG, "Dropping non-poll frame under superseded IV");
+    this->command_ = DecodedCommand{};
+    return Action::NONE;
+  }
+
   if (this->command_.type == CommandType::UNKNOWN) {
     ESP_LOGI(TAG, "Unhandled command: %s", format_hex_pretty(plaintext, ct_len).c_str());
-    return Action::COMMAND;  // the bridge still ACKs unknown frames
   }
 
   // DOORBELL is deliberately left out of the replay filter: under a fixed
@@ -131,7 +146,20 @@ LockSession::Action LockSession::process_frame(const std::string &frame) {
       ESP_LOGW(TAG, "Dropping action: ciphertext replay within session");
       return Action::NONE;
     }
-    this->record_ciphertext_(ciphertext, ct_len);
+    this->record_ciphertext_(context, ciphertext, ct_len);
+  }
+
+  std::memcpy(this->plaintext_.data(), plaintext, ct_len);
+  this->plaintext_size_ = ct_len;
+  this->response_iv_ = context.iv;
+  this->response_iv_valid_ = true;
+
+  if (uses_pending) {
+    this->active_ = this->pending_;
+    this->pending_ = CryptoContext{};
+    ESP_LOGV(TAG, "Pending IV promoted");
+  } else if (this->pending_.valid) {
+    ESP_LOGD(TAG, "Accepted delayed state poll under previous IV");
   }
 
   return Action::COMMAND;
@@ -155,39 +183,59 @@ size_t LockSession::encrypt_response(const FrameHeader &header, const uint8_t *p
   out[1] = header.key_id;
   out[2] = header.seq_a;
   out[3] = header.seq_b;
-  if (!this->xcrypt_(plaintext, length, out + HEADER_LEN)) {
+  if (!this->response_iv_valid_ ||
+      header.seq_a != this->response_iv_[0] ||
+      header.seq_b != this->response_iv_[1]) {
+    ESP_LOGE(TAG, "Cannot encrypt response: no matching RX IV context");
+    return 0;
+  }
+  if (!this->xcrypt_(this->response_iv_, plaintext, length, out + HEADER_LEN)) {
     return 0;
   }
   return HEADER_LEN + length;
 }
 
-bool LockSession::xcrypt_(const uint8_t *input, size_t length, uint8_t *output) {
-  return aes_ctr_xcrypt(this->aes_key_,
-                        this->iv_response_.data() + IV_RESPONSE_HEADER,
-                        input, output, length);
+bool LockSession::xcrypt_(const std::array<uint8_t, AES_IV_SIZE> &iv,
+                          const uint8_t *input, size_t length, uint8_t *output) {
+  return aes_ctr_xcrypt(this->aes_key_, iv.data(), input, output, length);
 }
 
-void LockSession::rotate_iv_() {
-  for (size_t i = 0; i < AES_IV_SIZE; i += 4) {
-    const uint32_t value = esp_random();
-    std::memcpy(this->iv_response_.data() + IV_RESPONSE_HEADER + i, &value, 4);
+void LockSession::rotate_pending_iv_() {
+  this->pending_ = CryptoContext{};
+  auto fill_iv = [this]() {
+    for (size_t i = 0; i < AES_IV_SIZE; i += 4) {
+      const uint32_t value = esp_random();
+      std::memcpy(this->pending_.iv.data() + i, &value, 4);
+    }
+  };
+  fill_iv();
+
+  // seq_a/seq_b are the only generation selector carried on the wire. Avoid
+  // an ambiguous active/pending pair. Bound the retries so a broken RNG
+  // cannot stall the BLE task; the final bit flip still makes the pair unique.
+  size_t retries = 0;
+  while (this->active_.valid && this->pending_.iv[0] == this->active_.iv[0] &&
+         this->pending_.iv[1] == this->active_.iv[1] && retries++ < 4) {
+    fill_iv();
   }
-  ESP_LOGV(TAG, "IV rotated: %s",
-           format_hex_pretty(this->iv_response_.data() + IV_RESPONSE_HEADER, AES_IV_SIZE).c_str());
-}
-
-void LockSession::clear_replay_history_() {
-  this->replay_head_ = 0;
-  for (auto &entry : this->replay_history_) {
-    entry.length = 0;
+  if (this->active_.valid && this->pending_.iv[0] == this->active_.iv[0] &&
+      this->pending_.iv[1] == this->active_.iv[1]) {
+    this->pending_.iv[1] ^= 0x01;
   }
+  this->pending_.valid = true;
+  std::memcpy(this->iv_response_.data() + IV_RESPONSE_HEADER,
+              this->pending_.iv.data(), AES_IV_SIZE);
+  ESP_LOGV(TAG, "Pending IV: %s",
+           format_hex_pretty(this->pending_.iv.data(), AES_IV_SIZE).c_str());
 }
 
-bool LockSession::is_replayed_ciphertext_(const uint8_t *ciphertext, size_t length) const {
+bool LockSession::is_replayed_ciphertext_(const CryptoContext &context,
+                                          const uint8_t *ciphertext,
+                                          size_t length) const {
   if (length == 0 || length > MAX_PAYLOAD) {
     return false;
   }
-  for (const auto &entry : this->replay_history_) {
+  for (const auto &entry : context.replay_history) {
     if (entry.length == length && std::memcmp(entry.data.data(), ciphertext, length) == 0) {
       return true;
     }
@@ -195,14 +243,21 @@ bool LockSession::is_replayed_ciphertext_(const uint8_t *ciphertext, size_t leng
   return false;
 }
 
-void LockSession::record_ciphertext_(const uint8_t *ciphertext, size_t length) {
+void LockSession::record_ciphertext_(CryptoContext &context,
+                                     const uint8_t *ciphertext, size_t length) {
   if (length == 0 || length > MAX_PAYLOAD) {
     return;
   }
-  ReplayEntry &slot = this->replay_history_[this->replay_head_];
+  ReplayEntry &slot = context.replay_history[context.replay_head];
   std::memcpy(slot.data.data(), ciphertext, length);
   slot.length = length;
-  this->replay_head_ = (this->replay_head_ + 1) % REPLAY_HISTORY_SIZE;
+  context.replay_head = (context.replay_head + 1) % REPLAY_HISTORY_SIZE;
+}
+
+bool LockSession::seq_matches_(const CryptoContext &context,
+                               const FrameHeader &header) const {
+  return context.valid && header.seq_a == context.iv[0] &&
+         header.seq_b == context.iv[1];
 }
 
 }  // namespace switchbot_keypad_bridge

--- a/components/switchbot_keypad_bridge/lock_session.h
+++ b/components/switchbot_keypad_bridge/lock_session.h
@@ -68,8 +68,8 @@ class LockSession {
   size_t plaintext_size() const { return this->plaintext_size_; }
 
   // The 20-byte session-IV response to notify after SEND_IV:
-  // [0x01, 0x00, 0x00, 0x00, IV(16)]. The trailing 16 bytes double as the
-  // AES-CTR IV of the live session.
+  // [0x01, 0x00, 0x00, 0x00, IV(16)]. The trailing 16 bytes are the pending
+  // AES-CTR IV; it becomes active when the first frame using it arrives.
   const uint8_t *iv_response() const { return this->iv_response_.data(); }
   size_t iv_response_size() const { return this->iv_response_.size(); }
 
@@ -80,15 +80,15 @@ class LockSession {
                           size_t length, uint8_t out[MAX_PACKET]);
 
  private:
+  static constexpr size_t AES_IV_SIZE = 16;
+  static constexpr size_t REPLAY_HISTORY_SIZE = 8;
+
   bool is_iv_request_(const std::string &frame) const;
-  void rotate_iv_();
+  void rotate_pending_iv_();
 
   // AES-CTR is symmetric, so a single primitive covers both directions.
-  bool xcrypt_(const uint8_t *input, size_t length, uint8_t *output);
-
-  void clear_replay_history_();
-  bool is_replayed_ciphertext_(const uint8_t *ciphertext, size_t length) const;
-  void record_ciphertext_(const uint8_t *ciphertext, size_t length);
+  bool xcrypt_(const std::array<uint8_t, AES_IV_SIZE> &iv, const uint8_t *input,
+               size_t length, uint8_t *output);
 
   psa_key_id_t aes_key_{PSA_KEY_ID_NULL};
 
@@ -98,18 +98,39 @@ class LockSession {
   // no encrypted frame is accepted until an IV handshake has set it.
   uint8_t slot_id_{0x00};
 
-  std::array<uint8_t, 20> iv_response_{0x01, 0x00, 0x00, 0x00};
-  bool iv_established_{false};
-
-  // Per-session anti-replay state. Reset when the crypto session is invalidated
-  // and on every IV re-negotiation.
-  static constexpr size_t REPLAY_HISTORY_SIZE = 8;
   struct ReplayEntry {
     std::array<uint8_t, MAX_PAYLOAD> data{};
     size_t length{0};
   };
-  std::array<ReplayEntry, REPLAY_HISTORY_SIZE> replay_history_{};
-  size_t replay_head_{0};
+
+  // An IV and its replay window form one logical crypto generation. A new IV
+  // remains pending until the keypad proves it switched by sending a frame
+  // whose seq bytes match it. Keeping the previous generation alive during
+  // that hand-off lets us answer an already-in-flight state poll without
+  // reopening old lock/unlock actions.
+  struct CryptoContext {
+    std::array<uint8_t, AES_IV_SIZE> iv{};
+    std::array<ReplayEntry, REPLAY_HISTORY_SIZE> replay_history{};
+    size_t replay_head{0};
+    bool valid{false};
+  };
+
+  bool is_replayed_ciphertext_(const CryptoContext &context,
+                               const uint8_t *ciphertext, size_t length) const;
+  void record_ciphertext_(CryptoContext &context, const uint8_t *ciphertext,
+                          size_t length);
+  bool seq_matches_(const CryptoContext &context, const FrameHeader &header) const;
+
+  CryptoContext active_{};
+  CryptoContext pending_{};
+
+  std::array<uint8_t, 20> iv_response_{0x01, 0x00, 0x00, 0x00};
+
+  // Exact IV used to decrypt the most recent COMMAND. Responses must use the
+  // same generation, especially for a late state poll under active_ while a
+  // newer pending_ IV has already been advertised.
+  std::array<uint8_t, AES_IV_SIZE> response_iv_{};
+  bool response_iv_valid_{false};
 
   FrameHeader header_{};
   DecodedCommand command_{};

--- a/components/switchbot_keypad_bridge/lock_session.h
+++ b/components/switchbot_keypad_bridge/lock_session.h
@@ -40,17 +40,21 @@ class LockSession {
   };
 
   // (Re-)point the session at an imported PSA AES-CTR key. The bridge owns
-  // key generation, NVS persistence and PSA import (including the unpair
+  // key generation, NVS persistence and PSA import (including reset-pairing
   // rotation); the session only uses the handle.
   void set_aes_key(psa_key_id_t key) { this->aes_key_ = key; }
 
-  // Drop all per-connection state: IV, replay history. Called on connect,
-  // disconnect and unpair. The learned token slot survives — once adopted
-  // from an IV request it is a property of the paired keypad, not of one
-  // connection.
+  // Drop the crypto session state. Used when the shared key changes or the
+  // pairing is reset; ordinary BLE reconnects may continue the same SwitchBot
+  // session and must keep the IV alive.
   void reset();
 
-  // Forget the learned token slot as well (unpair only).
+  // Clear transient decoded-frame state while preserving the negotiated IV and
+  // replay window. Called on BLE connect/disconnect events because some
+  // keypads continue the same logical session after a transport reconnect.
+  void reset_transport();
+
+  // Forget the learned token slot as well (pairing reset only).
   void forget_slot() { this->slot_id_ = 0x00; }
 
   // Validate, decrypt and decode one received frame. On COMMAND the decoded
@@ -60,6 +64,8 @@ class LockSession {
   // Valid after process_frame() returned COMMAND.
   const FrameHeader &header() const { return this->header_; }
   const DecodedCommand &command() const { return this->command_; }
+  const uint8_t *plaintext() const { return this->plaintext_.data(); }
+  size_t plaintext_size() const { return this->plaintext_size_; }
 
   // The 20-byte session-IV response to notify after SEND_IV:
   // [0x01, 0x00, 0x00, 0x00, IV(16)]. The trailing 16 bytes double as the
@@ -87,16 +93,16 @@ class LockSession {
   psa_key_id_t aes_key_{PSA_KEY_ID_NULL};
 
   // Token-slot key_id the keypad uses post-pairing. Auto-learned from the
-  // IV-request frame the keypad sends as the first message of every session
-  // (Original/Touch=0x88, Vision/Vision Pro=0xC6, …). 0x00 = not yet seen;
-  // no encrypted frame is accepted until the IV handshake has set it.
+  // IV-request frame the keypad sends when it starts a logical session
+  // (Original/Touch=0x88, Vision/Vision Pro=0xC6, ...). 0x00 = not yet seen;
+  // no encrypted frame is accepted until an IV handshake has set it.
   uint8_t slot_id_{0x00};
 
   std::array<uint8_t, 20> iv_response_{0x01, 0x00, 0x00, 0x00};
   bool iv_established_{false};
 
-  // Per-session anti-replay state. Reset on connect, disconnect, and on
-  // every IV re-negotiation.
+  // Per-session anti-replay state. Reset when the crypto session is invalidated
+  // and on every IV re-negotiation.
   static constexpr size_t REPLAY_HISTORY_SIZE = 8;
   struct ReplayEntry {
     std::array<uint8_t, MAX_PAYLOAD> data{};
@@ -107,6 +113,8 @@ class LockSession {
 
   FrameHeader header_{};
   DecodedCommand command_{};
+  std::array<uint8_t, MAX_PAYLOAD> plaintext_{};
+  size_t plaintext_size_{0};
 };
 
 }  // namespace switchbot_keypad_bridge

--- a/components/switchbot_keypad_bridge/mac_utils.h
+++ b/components/switchbot_keypad_bridge/mac_utils.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // MAC-address string/byte conversions shared by the cloud client, the
-// pairer, the pairing UI and the bridge. Pure string handling — no NimBLE
+// pairer, the setup UI and the bridge. Pure string handling — no NimBLE
 // or ESP-IDF dependency.
 
 #include <cstdint>

--- a/components/switchbot_keypad_bridge/pairing_ui.cpp
+++ b/components/switchbot_keypad_bridge/pairing_ui.cpp
@@ -7,6 +7,7 @@
 
 #include <cJSON.h>
 
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 #include "ble_utils.h"
 #include "keypad_advert.h"
@@ -17,6 +18,8 @@ namespace switchbot_keypad_bridge {
 
 namespace {
 const char *const TAG = "switchbot_keypad_bridge.ui";
+constexpr uint8_t SHARED_SLOT_ORIGINAL = 0x88;
+constexpr uint8_t SHARED_SLOT_VISION   = 0xC6;
 
 // Helpers to register a URI with the user_ctx set to a PairingUi instance.
 httpd_uri_t make_uri(const char *path, httpd_method_t method,
@@ -38,16 +41,22 @@ bool PairingUi::start(uint16_t port) {
   }
   httpd_config_t cfg = HTTPD_DEFAULT_CONFIG();
   cfg.server_port = port;
-  cfg.max_uri_handlers = 8;
+  cfg.max_uri_handlers = 12;
   cfg.uri_match_fn = httpd_uri_match_wildcard;
   cfg.stack_size = 8192;  // headroom for the BLE scan run from /api/keypads
   cfg.lru_purge_enable = true;
+  // Browsers open up to 6 keep-alive connections; with the default of 7 the
+  // wizard could starve LWIP's socket pool (shared with the HA API, log
+  // streams and the cloud TLS client → "failed to create socket"). 4 is
+  // plenty for one wizard page, and LRU purge recycles idle sessions.
+  cfg.max_open_sockets = 4;
 
   if (httpd_start(&this->server_, &cfg) != ESP_OK) {
     ESP_LOGE(TAG, "httpd_start failed on port %u", port);
     this->server_ = nullptr;
     return false;
   }
+  this->last_activity_ms_.store(millis(), std::memory_order_relaxed);
 
   auto reg = [this](const char *path, httpd_method_t m,
                     esp_err_t (*h)(httpd_req_t *)) {
@@ -59,8 +68,11 @@ bool PairingUi::start(uint16_t port) {
   reg("/api/keypads",       HTTP_GET,  PairingUi::handle_keypads_);
   reg("/api/pair",          HTTP_POST, PairingUi::handle_pair_);
   reg("/api/pair/status",   HTTP_GET,  PairingUi::handle_pair_status_);
+  reg("/api/locks",            HTTP_GET,  PairingUi::handle_locks_);
+  reg("/api/lock/link",        HTTP_POST, PairingUi::handle_lock_link_);
+  reg("/api/lock/link/status", HTTP_GET,  PairingUi::handle_lock_link_status_);
 
-  ESP_LOGI(TAG, "Pairing UI listening on http://<device>:%u/", port);
+  ESP_LOGI(TAG, "Setup UI listening on http://<device>:%u/", port);
   return true;
 }
 
@@ -69,15 +81,100 @@ void PairingUi::stop() {
     httpd_stop(this->server_);
     this->server_ = nullptr;
   }
+  this->last_activity_ms_.store(0, std::memory_order_relaxed);
+}
+
+bool PairingUi::stop_if_idle(uint32_t now_ms, uint32_t timeout_ms) {
+  if (this->server_ == nullptr) {
+    return false;
+  }
+  const uint32_t last = this->last_activity_ms_.load(std::memory_order_relaxed);
+  if (last == 0 || static_cast<uint32_t>(now_ms - last) < timeout_ms) {
+    return false;
+  }
+  // Never pull the server out from under a running BLE job: the browser may
+  // be gone, but the job's completion still has to be observed (poll_jobs).
+  if (this->pairer_.state() == KeypadPairer::State::RUNNING ||
+      this->linker_.state() == LockLinker::State::RUNNING) {
+    return false;
+  }
+  this->stop();
+  return true;
+}
+
+void PairingUi::poll_jobs() {
+  // Runs every main-loop iteration, so the cheap state()/flag checks come
+  // first; the full Status snapshot (string copies) is taken only on the
+  // one iteration that actually consumes a SUCCESS.
+  std::string pairing_job_id;
+  std::string pairing_keypad_name;
+  bool pairing_armed = false;
+  std::string link_job_id;
+  bool link_armed = false;
+  {
+    std::lock_guard<std::mutex> lk(this->jobs_mu_);
+    pairing_armed = !this->success_notified_ && !this->pairing_job_id_.empty();
+    if (pairing_armed) {
+      pairing_job_id = this->pairing_job_id_;
+      pairing_keypad_name = this->pairing_keypad_name_;
+    }
+    link_armed = !this->link_notified_ && !this->link_job_id_.empty();
+    if (link_armed) {
+      link_job_id = this->link_job_id_;
+    }
+  }
+
+  if (pairing_armed && this->pairer_.state() == KeypadPairer::State::SUCCESS) {
+    const KeypadPairer::Status st = this->pairer_.status();
+    if (st.job_id == pairing_job_id) {
+      bool notify = false;
+      {
+        std::lock_guard<std::mutex> lk(this->jobs_mu_);
+        if (!this->success_notified_ && this->pairing_job_id_ == st.job_id) {
+          this->success_notified_ = true;
+          this->keypad_paired_.store(true);
+          notify = true;
+        }
+      }
+      // Fire outside jobs_mu_: callbacks belong to the bridge, not the UI's
+      // internal bookkeeping, and should not run while a UI mutex is held.
+      if (notify && this->on_paired_cb_) {
+        this->on_paired_cb_(pairing_keypad_name, st.keypad_mac, st.family);
+      }
+    }
+  }
+
+  if (link_armed && this->linker_.state() == LockLinker::State::SUCCESS) {
+    const LockLinker::Status st = this->linker_.status();
+    if (st.job_id == link_job_id) {
+      bool notify = false;
+      {
+        std::lock_guard<std::mutex> lk(this->jobs_mu_);
+        if (!this->link_notified_ && this->link_job_id_ == st.job_id) {
+          this->link_notified_ = true;
+          this->lock_linked_.store(true);
+          notify = true;
+        }
+      }
+      if (notify && this->on_lock_linked_cb_) {
+        this->on_lock_linked_cb_(st.name, st.mac, st.model, st.slot_id);
+      }
+    }
+  }
+}
+
+void PairingUi::touch_activity_() {
+  this->last_activity_ms_.store(millis(), std::memory_order_relaxed);
 }
 
 // ── URI handlers ──────────────────────────────────────────────────────────
 
 esp_err_t PairingUi::handle_root_(httpd_req_t *req) {
   auto *self = static_cast<PairingUi *>(req->user_ctx);
+  self->touch_activity_();
   if (self->html_ == nullptr || self->html_len_ == 0) {
     return reply_error_(req, "500 Internal Server Error",
-                        "Pairing UI was not embedded in this build.");
+                        "Setup UI was not embedded in this build.");
   }
   httpd_resp_set_type(req, "text/html; charset=utf-8");
   httpd_resp_set_hdr(req, "Cache-Control", "no-store");
@@ -118,6 +215,72 @@ std::string extract_json_str(const std::string &body, const char *key) {
   }
   cJSON_Delete(root);
   return out;
+}
+
+bool parse_key_id_hex(const std::string &hex, uint8_t &out) {
+  if (hex.empty()) return false;
+  char *end = nullptr;
+  const long value = std::strtol(hex.c_str(), &end, 16);
+  if (end == hex.c_str() || end == nullptr || *end != '\0' ||
+      value < 0 || value > 0xFF) {
+    return false;
+  }
+  out = static_cast<uint8_t>(value);
+  return true;
+}
+
+uint8_t shared_slot_for_family(KeypadFamily family) {
+  return family == KeypadFamily::VISION ? SHARED_SLOT_VISION : SHARED_SLOT_ORIGINAL;
+}
+
+const CloudClient::AccountDevice *find_account_device_(
+    const std::vector<CloudClient::AccountDevice> &devices,
+    const std::string &mac) {
+  for (const auto &dev : devices) {
+    if (dev.mac_pretty == mac || dev.mac == mac) {
+      return &dev;
+    }
+  }
+  return nullptr;
+}
+
+bool fetch_comm_key_16_(CloudClient &cloud,
+                        const CloudClient::AccountDevice &device,
+                        const char *device_label,
+                        uint8_t &key_id,
+                        std::array<uint8_t, 16> &key,
+                        std::string &err) {
+  std::string key_id_hex;
+  std::vector<uint8_t> key_bytes;
+  if (!cloud.fetch_device_key(device.mac, key_id_hex, key_bytes, err)) {
+    return false;
+  }
+  if (key_bytes.size() != key.size()) {
+    err = "SwitchBot returned a malformed ";
+    err += device_label;
+    err += " key.";
+    return false;
+  }
+  if (!parse_key_id_hex(key_id_hex, key_id)) {
+    err = "SwitchBot returned a malformed ";
+    err += device_label;
+    err += " key id.";
+    return false;
+  }
+  std::memcpy(key.data(), key_bytes.data(), key.size());
+  return true;
+}
+
+template <typename LabelFn>
+std::string job_started_json_(const std::string &job_id, uint8_t step_count,
+                              LabelFn label_fn) {
+  cJSON *resp = cJSON_CreateObject();
+  cJSON_AddStringToObject(resp, "job_id", job_id.c_str());
+  cJSON *labels = cJSON_AddArrayToObject(resp, "labels");
+  for (uint8_t i = 0; i < step_count; ++i) {
+    cJSON_AddItemToArray(labels, cJSON_CreateString(label_fn(i)));
+  }
+  return json_take(resp);
 }
 
 // One nearby BLE device: strongest RSSI seen plus its SwitchBot service-data
@@ -162,6 +325,7 @@ std::map<std::string, NearbyDevice> scan_nearby(uint32_t duration_ms) {
 
 esp_err_t PairingUi::handle_login_(httpd_req_t *req) {
   auto *self = static_cast<PairingUi *>(req->user_ctx);
+  self->touch_activity_();
   std::string body = read_body_(req);
   std::string email    = extract_json_str(body, "email");
   std::string password = extract_json_str(body, "password");
@@ -177,11 +341,14 @@ esp_err_t PairingUi::handle_login_(httpd_req_t *req) {
   }
   cJSON *resp = cJSON_CreateObject();
   cJSON_AddStringToObject(resp, "region", self->cloud_.region().c_str());
+  cJSON_AddBoolToObject(resp, "keypad_paired", self->keypad_paired_.load());
+  cJSON_AddBoolToObject(resp, "lock_linked", self->lock_linked_.load());
   return reply_json_(req, json_take(resp).c_str());
 }
 
 esp_err_t PairingUi::handle_keypads_(httpd_req_t *req) {
   auto *self = static_cast<PairingUi *>(req->user_ctx);
+  self->touch_activity_();
   if (!self->cloud_.is_logged_in()) {
     return reply_error_(req, "401 Unauthorized", "Sign in first.");
   }
@@ -244,8 +411,128 @@ esp_err_t PairingUi::handle_keypads_(httpd_req_t *req) {
   return reply_json_(req, json_take(arr, "[]").c_str());
 }
 
+esp_err_t PairingUi::handle_locks_(httpd_req_t *req) {
+  auto *self = static_cast<PairingUi *>(req->user_ctx);
+  self->touch_activity_();
+  if (!self->cloud_.is_logged_in()) {
+    return reply_error_(req, "401 Unauthorized", "Sign in first.");
+  }
+  if (!self->keypad_paired_.load()) {
+    return reply_error_(req, "409 Conflict", "Link a keypad before linking a lock.");
+  }
+
+  std::vector<CloudClient::AccountDevice> devices;
+  std::string err;
+  if (!self->cloud_.list_devices(devices, err)) {
+    ESP_LOGW(TAG, "list_devices failed: %s", err.c_str());
+    return reply_error_(req, "502 Bad Gateway", err);
+  }
+
+  const std::map<std::string, NearbyDevice> nearby = scan_nearby(8000);
+  cJSON *arr = cJSON_CreateArray();
+  unsigned shown = 0;
+  for (const auto &dev : devices) {
+    const PhysicalLockModel model = physical_lock_model_from_api_type(dev.device_type);
+    if (model == PhysicalLockModel::UNKNOWN) continue;
+
+    const auto hit = nearby.find(dev.mac_pretty);
+    cJSON *o = cJSON_CreateObject();
+    cJSON_AddStringToObject(o, "mac", dev.mac_pretty.c_str());
+    cJSON_AddStringToObject(o, "name", dev.name.c_str());
+    cJSON_AddStringToObject(o, "model", physical_lock_model_str(model));
+    cJSON_AddStringToObject(o, "device_type", dev.device_type.c_str());
+    cJSON_AddBoolToObject(o, "online", hit != nearby.end());
+    if (hit != nearby.end()) {
+      cJSON_AddNumberToObject(o, "rssi", hit->second.rssi);
+    } else {
+      cJSON_AddNullToObject(o, "rssi");
+    }
+    cJSON_AddItemToArray(arr, o);
+    ++shown;
+  }
+  ESP_LOGI(TAG, "GET /api/locks -> %u lock(s) of %u account device(s)",
+           shown, static_cast<unsigned>(devices.size()));
+  return reply_json_(req, json_take(arr, "[]").c_str());
+}
+
+esp_err_t PairingUi::handle_lock_link_(httpd_req_t *req) {
+  auto *self = static_cast<PairingUi *>(req->user_ctx);
+  self->touch_activity_();
+  std::string body = read_body_(req);
+  std::string mac = extract_json_str(body, "mac");
+  if (mac.empty()) {
+    return reply_error_(req, "400 Bad Request", "Missing lock mac.");
+  }
+  if (!self->cloud_.is_logged_in()) {
+    return reply_error_(req, "401 Unauthorized", "Sign in first.");
+  }
+  if (!self->keypad_paired_.load()) {
+    return reply_error_(req, "409 Conflict", "Link a keypad before linking a lock.");
+  }
+  // Same one-shot rule as /api/pair: re-linking goes through Reset.
+  if (self->lock_linked_.load()) {
+    return reply_error_(req, "409 Conflict",
+                        "A lock is already linked to this bridge. "
+                        "Press the Reset button to start over.");
+  }
+
+  std::vector<CloudClient::AccountDevice> devices;
+  std::string err;
+  if (!self->cloud_.list_devices(devices, err)) {
+    return reply_error_(req, "502 Bad Gateway", err);
+  }
+  const CloudClient::AccountDevice *found = find_account_device_(devices, mac);
+  if (found == nullptr) {
+    return reply_error_(req, "404 Not Found", "Lock not in this SwitchBot account.");
+  }
+
+  const PhysicalLockModel model = physical_lock_model_from_api_type(found->device_type);
+  if (model == PhysicalLockModel::UNKNOWN) {
+    return reply_error_(req, "400 Bad Request", "This SwitchBot device is not a supported Lock.");
+  }
+
+  // Bootstrap only: the lock communication key lets us install the bridge's
+  // shared keypad/lock key into the lock slot. It is not returned by the job,
+  // persisted to NVS, or used for day-to-day relay.
+  uint8_t lock_key_id = 0;
+  std::array<uint8_t, 16> lock_key{};
+  if (!fetch_comm_key_16_(self->cloud_, *found, "lock provisioning",
+                          lock_key_id, lock_key, err)) {
+    return reply_error_(req, "502 Bad Gateway", err);
+  }
+
+  LockLinker::Request lr;
+  lr.name = found->name;
+  lr.mac = found->mac_pretty;
+  lr.model = model;
+  lr.shared_key = self->shared_key_;
+  lr.shared_slot_id = shared_slot_for_family(
+      static_cast<KeypadFamily>(self->keypad_family_.load()));
+  lr.lock_key_id = lock_key_id;
+  lr.lock_key = lock_key;
+
+  std::string job_id = self->linker_.start(std::move(lr));
+  if (job_id.empty()) {
+    return reply_error_(req, "409 Conflict",
+                        "A lock-link job is already in progress.");
+  }
+  {
+    std::lock_guard<std::mutex> lk(self->jobs_mu_);
+    self->link_job_id_   = job_id;
+    self->link_notified_ = false;
+  }
+
+  return reply_json_(req,
+                     job_started_json_(job_id, LockLinker::step_count(),
+                                       [](uint8_t i) {
+                                         return LockLinker::step_label(i);
+                                       })
+                         .c_str());
+}
+
 esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   auto *self = static_cast<PairingUi *>(req->user_ctx);
+  self->touch_activity_();
   std::string body = read_body_(req);
   std::string mac  = extract_json_str(body, "mac");
   if (mac.empty()) {
@@ -260,6 +547,14 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   if (!self->cloud_.is_logged_in()) {
     return reply_error_(req, "401 Unauthorized", "Sign in first.");
   }
+  // Pairing is a one-shot: once confirmed it can only be redone through the
+  // Reset button (which also rotates the shared key). Without this gate the
+  // wizard's tabs could quietly re-run the whole handshake.
+  if (self->keypad_paired_.load()) {
+    return reply_error_(req, "409 Conflict",
+                        "A keypad is already linked to this bridge. "
+                        "Press the Reset button to start over.");
+  }
 
   // Confirm the MAC belongs to this account (and grab its pretty form + name).
   std::vector<CloudClient::AccountDevice> devices;
@@ -267,13 +562,7 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   if (!self->cloud_.list_devices(devices, err)) {
     return reply_error_(req, "502 Bad Gateway", err);
   }
-  const CloudClient::AccountDevice *found = nullptr;
-  for (const auto &dev : devices) {
-    if (dev.mac_pretty == mac || dev.mac == mac) {
-      found = &dev;
-      break;
-    }
-  }
+  const CloudClient::AccountDevice *found = find_account_device_(devices, mac);
   if (found == nullptr) {
     return reply_error_(req, "404 Not Found",
                         "Keypad not in this SwitchBot account.");
@@ -281,10 +570,10 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   ESP_LOGI(TAG, "/api/pair matched keypad '%s' (%s)",
            found->name.c_str(), found->mac_pretty.c_str());
 
-  // Fetch the keypad's current K14 from the SwitchBot cloud.
-  std::string key_id_hex;
-  std::vector<uint8_t> key_bytes;
-  if (!self->cloud_.fetch_keypad_key(found->mac, key_id_hex, key_bytes, err)) {
+  // Fetch the keypad's current communication key from the SwitchBot cloud.
+  uint8_t key_id = 0;
+  std::array<uint8_t, 16> key{};
+  if (!fetch_comm_key_16_(self->cloud_, *found, "keypad", key_id, key, err)) {
     return reply_error_(req, "502 Bad Gateway", err);
   }
 
@@ -292,8 +581,8 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   KeypadPairer::Request kr;
   kr.keypad_mac  = found->mac_pretty;
   kr.family      = family;
-  kr.key_id     = static_cast<int>(std::strtol(key_id_hex.c_str(), nullptr, 16));
-  kr.key        = std::move(key_bytes);
+  kr.key_id     = static_cast<int>(key_id);
+  kr.key.assign(key.begin(), key.end());
   kr.shared_token = self->shared_key_;
   kr.esp_mac = addr_bytes(NimBLEDevice::getAddress());
 
@@ -303,55 +592,75 @@ esp_err_t PairingUi::handle_pair_(httpd_req_t *req) {
   std::string job_id = self->pairer_.start(std::move(kr));
   if (job_id.empty()) {
     return reply_error_(req, "409 Conflict",
-                        "A pairing job is already in progress.");
+                        "A keypad link job is already in progress.");
   }
   // Bind name + job id together, then arm the one-shot flag. start() has
-  // already moved the job to RUNNING, so a status poll landing here can
-  // no longer observe a previous job's lingering SUCCESS state.
-  self->pairing_keypad_name_ = keypad_name;
-  self->pairing_job_id_      = job_id;
-  self->success_notified_    = false;
-  cJSON *resp = cJSON_CreateObject();
-  cJSON_AddStringToObject(resp, "job_id", job_id.c_str());
+  // already moved the job to RUNNING, so poll_jobs() can no longer observe
+  // a previous job's lingering SUCCESS state.
+  {
+    std::lock_guard<std::mutex> lk(self->jobs_mu_);
+    self->pairing_keypad_name_ = keypad_name;
+    self->pairing_job_id_      = job_id;
+    self->success_notified_    = false;
+  }
+  return reply_json_(req,
+                     job_started_json_(job_id, KeypadPairer::step_count(family),
+                                       [family](uint8_t i) {
+                                         return KeypadPairer::step_label(family, i);
+                                       })
+                         .c_str());
   // Step labels for the progress stepper — the wizard renders these, so the
   // pairer stays the single source of truth for count, order and wording.
   // The Vision family has one extra step (enabling the doorbell).
-  cJSON *labels = cJSON_AddArrayToObject(resp, "labels");
-  for (uint8_t i = 0; i < KeypadPairer::step_count(family); ++i) {
-    cJSON_AddItemToArray(labels, cJSON_CreateString(KeypadPairer::step_label(family, i)));
-  }
-  return reply_json_(req, json_take(resp).c_str());
 }
 
-esp_err_t PairingUi::handle_pair_status_(httpd_req_t *req) {
-  auto *self = static_cast<PairingUi *>(req->user_ctx);
-  KeypadPairer::Status st = self->pairer_.status();
-
-  // Fire the paired callback exactly once, and only for the job this UI
-  // actually started — matched by job id. This is what guarantees the
-  // entity is renamed to the keypad just paired, never a previous one.
-  if (st.state == KeypadPairer::State::SUCCESS && !self->success_notified_ &&
-      st.job_id == self->pairing_job_id_ && !self->pairing_job_id_.empty()) {
-    self->success_notified_ = true;
-    if (self->on_paired_cb_) {
-      self->on_paired_cb_(self->pairing_keypad_name_, st.keypad_mac, st.family);
-    }
-  }
-
-  const bool done = st.state == KeypadPairer::State::SUCCESS ||
-                    st.state == KeypadPairer::State::FAILED;
-
+// Serialize a job snapshot for the wizard's polling loop. Success callbacks
+// are NOT fired here — poll_jobs() owns that from the main loop, so a job
+// completes correctly even when the browser stopped polling.
+namespace {
+std::string job_status_json(uint8_t step, uint8_t total,
+                            const std::string &message, bool done,
+                            bool failed, const std::string &error) {
   cJSON *resp = cJSON_CreateObject();
-  cJSON_AddNumberToObject(resp, "step", st.step);
-  cJSON_AddNumberToObject(resp, "total", st.total);
-  cJSON_AddStringToObject(resp, "message", st.message.c_str());
+  cJSON_AddNumberToObject(resp, "step", step);
+  cJSON_AddNumberToObject(resp, "total", total);
+  cJSON_AddStringToObject(resp, "message", message.c_str());
   cJSON_AddBoolToObject(resp, "done", done);
-  if (st.state == KeypadPairer::State::FAILED) {
-    cJSON_AddStringToObject(resp, "error", st.error.c_str());
+  if (failed) {
+    cJSON_AddStringToObject(resp, "error", error.c_str());
   } else {
     cJSON_AddNullToObject(resp, "error");
   }
-  return reply_json_(req, json_take(resp).c_str());
+  return json_take(resp);
+}
+
+template <typename Status, typename State>
+std::string job_status_json_(const Status &st, State success_state,
+                             State failed_state) {
+  const bool failed = st.state == failed_state;
+  const bool done = failed || st.state == success_state;
+  return job_status_json(st.step, st.total, st.message, done, failed, st.error);
+}
+}  // namespace
+
+esp_err_t PairingUi::handle_pair_status_(httpd_req_t *req) {
+  auto *self = static_cast<PairingUi *>(req->user_ctx);
+  self->touch_activity_();
+  const KeypadPairer::Status st = self->pairer_.status();
+  return reply_json_(
+      req, job_status_json_(st, KeypadPairer::State::SUCCESS,
+                            KeypadPairer::State::FAILED)
+               .c_str());
+}
+
+esp_err_t PairingUi::handle_lock_link_status_(httpd_req_t *req) {
+  auto *self = static_cast<PairingUi *>(req->user_ctx);
+  self->touch_activity_();
+  const LockLinker::Status st = self->linker_.status();
+  return reply_json_(
+      req, job_status_json_(st, LockLinker::State::SUCCESS,
+                            LockLinker::State::FAILED)
+               .c_str());
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────

--- a/components/switchbot_keypad_bridge/pairing_ui.h
+++ b/components/switchbot_keypad_bridge/pairing_ui.h
@@ -1,13 +1,17 @@
 #pragma once
 
-// Lightweight HTTP server that hosts the on-device pairing wizard.
+// Lightweight HTTP server that hosts the on-device setup wizard.
 //
 // Endpoints:
 //   GET  /                       → embedded HTML (single self-contained page)
-//   POST /api/login              → {email,password} → {region} | 401
+//   POST /api/login              → {email,password} → {region, keypad_paired,
+//                                   lock_linked} | 401
 //   GET  /api/keypads            → [ {mac, name, model, online, rssi} ]
 //   POST /api/pair               → {mac} → {job_id, labels: [step names]}
 //   GET  /api/pair/status        → {step, total, message, done, error}
+//   GET  /api/locks              → [ {mac, name, model, online, rssi} ]
+//   POST /api/lock/link          → {mac} → {job_id, labels: [step names]}
+//   GET  /api/lock/link/status   → {step, total, message, done, error}
 //
 // The server uses ESP-IDF's `esp_http_server` (already pulled in by NimBLE
 // and the ESP-IDF framework — no extra managed components needed).
@@ -17,15 +21,19 @@
 #include <esp_http_server.h>
 
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <mutex>
 #include <string>
 
 #include "cloud_client.h"
 #include "keypad_advert.h"
 #include "keypad_pairer.h"
+#include "lock_linker.h"
+#include "physical_lock.h"
 
 namespace esphome {
 namespace switchbot_keypad_bridge {
@@ -43,6 +51,11 @@ class PairingUi {
   // The bridge's 16-byte AES session key — injected into the keypad's lock
   // slot during pairing.
   void set_shared_key(const std::array<uint8_t, 16> &key) { this->shared_key_ = key; }
+  void set_keypad_paired(bool paired) { this->keypad_paired_.store(paired); }
+  void set_keypad_family(KeypadFamily family) {
+    this->keypad_family_.store(static_cast<uint8_t>(family));
+  }
+  void set_lock_linked(bool linked) { this->lock_linked_.store(linked); }
 
   // The embedded UI page, gzip-compressed and baked into flash by codegen
   // (see __init__.py); served verbatim with Content-Encoding: gzip.
@@ -60,7 +73,26 @@ class PairingUi {
     this->on_paired_cb_ = std::move(cb);
   }
 
+  using OnLockLinkedCallback = std::function<void(
+      const std::string &name, const std::string &mac, PhysicalLockModel model,
+      uint8_t slot_id)>;
+  void set_on_lock_linked_callback(OnLockLinkedCallback cb) {
+    this->on_lock_linked_cb_ = std::move(cb);
+  }
+
   bool is_running() const { return this->server_ != nullptr; }
+
+  // Idle shutdown: stops the server once no request has arrived for
+  // `timeout_ms`. Refuses to fire while a pairing or lock-link job is still
+  // RUNNING, so closing the browser mid-job can never kill the server under
+  // an in-flight BLE handshake.
+  bool stop_if_idle(uint32_t now_ms, uint32_t timeout_ms = 5 * 60 * 1000);
+
+  // Fires the one-shot success callbacks for both background jobs. Called
+  // from the bridge's loop() so a pairing/link that completes after the
+  // browser disappeared is still applied — the HTTP status handlers are pure
+  // reporters and never fire callbacks.
+  void poll_jobs();
 
  private:
   // URI handler trampolines — esp_http_server takes a C function, so the
@@ -71,27 +103,41 @@ class PairingUi {
   static esp_err_t handle_keypads_(httpd_req_t *req);
   static esp_err_t handle_pair_(httpd_req_t *req);
   static esp_err_t handle_pair_status_(httpd_req_t *req);
+  static esp_err_t handle_locks_(httpd_req_t *req);
+  static esp_err_t handle_lock_link_(httpd_req_t *req);
+  static esp_err_t handle_lock_link_status_(httpd_req_t *req);
 
   static esp_err_t reply_json_(httpd_req_t *req, const char *json,
                                const char *status = "200 OK");
   static esp_err_t reply_error_(httpd_req_t *req, const char *status,
                                 const std::string &message);
   static std::string read_body_(httpd_req_t *req);
+  void touch_activity_();
 
   httpd_handle_t server_{nullptr};
   CloudClient    cloud_{};
   KeypadPairer   pairer_{};
+  LockLinker     linker_{};
   std::array<uint8_t, 16> shared_key_{};
+  std::atomic<uint8_t> keypad_family_{static_cast<uint8_t>(KeypadFamily::ORIGINAL)};
   const uint8_t *html_{nullptr};
   size_t         html_len_{0};
   OnPairedCallback on_paired_cb_;
-  // Identify the pairing this UI started. The success handler matches
-  // Status::job_id against pairing_job_id_ before firing on_paired_cb_,
-  // so a previous job's lingering SUCCESS can never apply the wrong
-  // name. All three fields are touched only by the HTTP-server task.
+  OnLockLinkedCallback on_lock_linked_cb_;
+  std::atomic<bool> keypad_paired_{false};
+  std::atomic<bool> lock_linked_{false};
+  std::atomic<uint32_t> last_activity_ms_{0};
+  // Identify the jobs this UI started. poll_jobs() matches Status::job_id
+  // against the stored id before firing the one-shot callbacks, so a previous
+  // job's lingering SUCCESS can never apply the wrong device. Job starts run
+  // on the HTTP-server task while poll_jobs() runs on the main loop — hence
+  // the mutex.
+  std::mutex     jobs_mu_;
   std::string    pairing_keypad_name_;
   std::string    pairing_job_id_;
   bool           success_notified_{false};
+  std::string    link_job_id_;
+  bool           link_notified_{false};
 
   // Keypads identified from their BLE advertisement, keyed by pretty MAC. A
   // keypad's model signature rides in the 0xFD3D service data, which for the

--- a/components/switchbot_keypad_bridge/pairing_ui.html
+++ b/components/switchbot_keypad_bridge/pairing_ui.html
@@ -218,6 +218,55 @@
   }
   .page-header .subtitle { color: var(--sb-cc2); font-size: 14px; margin: 0; }
 
+  /* -- Setup tabs -- */
+  .device-tabs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px;
+    padding: 4px;
+    margin-bottom: var(--sp-lg);
+    border: 1px solid var(--sb-divider);
+    border-radius: var(--radius-input);
+    background: rgba(0,0,0,0.035);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .device-tabs { background: rgba(255,255,255,0.045); }
+  }
+  :root[data-theme="dark"] .device-tabs { background: rgba(255,255,255,0.045); }
+  .device-tab {
+    border: 0;
+    border-radius: 10px;
+    background: transparent;
+    color: var(--sb-cc2);
+    padding: 10px 12px;
+    font: inherit;
+    font-size: 14px;
+    font-weight: 650;
+    cursor: pointer;
+    transition: background 150ms, color 150ms, box-shadow 150ms;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .device-tab.active {
+    background: var(--sb-card-bg);
+    color: var(--sb-primary-text);
+    box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+  }
+  .device-tab[aria-disabled="true"] {
+    color: var(--sb-support);
+    cursor: not-allowed;
+    opacity: 0.58;
+  }
+  .tab-note {
+    margin: calc(-1 * var(--sp-sm)) 0 var(--sp-lg);
+    background: var(--sb-blue-tip-bg);
+    color: var(--sb-cc2);
+    border: 1px solid rgba(68,126,239,0.18);
+    border-radius: var(--radius-input);
+    padding: 11px 13px;
+    font-size: 13px;
+    line-height: 1.45;
+  }
+
   /* ── Keypad cards ── */
   .keypads-list {
     display: flex; flex-direction: column; gap: var(--sp-sm);
@@ -428,6 +477,21 @@
     margin: 0 0 var(--sp-sm);
   }
   .result-hero .desc { color: var(--sb-cc2); font-size: 14px; margin: 0; }
+  .next-step {
+    background: var(--sb-blue-tip-bg);
+    border: 1px solid rgba(68,126,239,0.18);
+    border-radius: var(--radius-input);
+    padding: 12px 14px;
+    margin-top: var(--sp-md);
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--sb-cc2);
+  }
+  .next-step strong {
+    display: block;
+    color: var(--sb-primary-text);
+    margin-bottom: 2px;
+  }
   /* Retry button, below the error banner inside the card */
   #progress-result-error .btn { margin-top: var(--sp-lg); }
 
@@ -486,9 +550,11 @@
   <span>
     <button onclick="showScreen('login')" class="active">Login</button>
     <button onclick="showScreen('keypads')">Keypad list</button>
-    <button onclick="showScreen('progress'); previewProgress()">Pairing (Progress)</button>
-    <button onclick="showScreen('progress'); showResultSuccess()">Success</button>
-    <button onclick="showScreen('progress'); showResultError('Simulated error message.')">Error</button>
+    <button onclick="showScreen('locks'); previewLocks()">Lock list</button>
+    <button onclick="showScreen('progress'); previewProgress()">Linking (Progress)</button>
+    <button onclick="progressKind='keypad'; showScreen('progress'); showResultSuccess()">Success</button>
+    <button onclick="progressKind='lock'; showScreen('progress'); showResultSuccess()">Lock success</button>
+    <button onclick="progressKind='keypad'; showScreen('progress'); showResultError('Simulated error message.')">Error</button>
     <button onclick="toggleTheme()" id="theme-toggle" style="margin-left:8px;">🌙 Dark</button>
   </span>
 </div>
@@ -499,6 +565,14 @@
 </header>
 
 <main class="container">
+
+  <nav id="setup-tabs" class="device-tabs hidden" aria-label="Setup sections">
+    <button id="tab-keypads" class="device-tab active" type="button">Keypad</button>
+    <button id="tab-locks" class="device-tab" type="button" aria-disabled="true">Lock</button>
+  </nav>
+  <div id="lock-tab-note" class="tab-note hidden">
+    Link a keypad first. The Lock tab unlocks after the bridge has a shared key to relay.
+  </div>
 
   <!-- ─── Login ─── -->
   <section id="screen-login" class="screen">
@@ -541,7 +615,7 @@
   <section id="screen-keypads" class="screen hidden">
     <div class="page-header">
       <h2>Your keypads</h2>
-      <p class="subtitle">Select a keypad to pair with this bridge.</p>
+      <p class="subtitle">Select a keypad to link with this bridge.</p>
     </div>
 
     <div class="keypads-list" id="keypads-list">
@@ -567,7 +641,7 @@
             <span class="kp-badge online"><span class="dot"></span>−42 dBm</span>
           </div>
         </div>
-        <button class="btn-pair">Pair</button>
+        <button class="btn-pair">Link</button>
       </div>
 
       <div class="kp-card">
@@ -591,11 +665,25 @@
             <span class="kp-badge offline"><span class="dot"></span>Out of range</span>
           </div>
         </div>
-        <button class="btn-pair" disabled>Pair</button>
+        <button class="btn-pair" disabled>Link</button>
       </div>
     </div>
 
     <button id="rescan-btn" class="btn btn-secondary">↻ Rescan</button>
+  </section>
+
+  <!-- ─── Lock list ─── -->
+  <section id="screen-locks" class="screen hidden">
+    <div class="page-header">
+      <h2>Your lock</h2>
+      <p class="subtitle">Select the physical lock to relay keypad commands to.</p>
+    </div>
+
+    <div class="keypads-list" id="locks-list">
+      <div class="empty-state">Sign in to load locks.</div>
+    </div>
+
+    <button id="rescan-locks-btn" class="btn btn-secondary">↻ Rescan</button>
   </section>
 
   <!-- ─── Pairing progress ─── -->
@@ -611,9 +699,10 @@
 
     <div class="card" id="progress-card-content">
       <!-- These static steps exist only for the file:// design preview. At
-           runtime startPair() empties the stepper and fills it from the
-           `labels` array in the /api/pair response — the firmware's step list
-           is the single source of truth; nothing here is shown on-device. -->
+           runtime beginProgress() empties the stepper and fillStepper() fills
+           it from the `labels` array in the /api/pair or /api/lock/link
+           response — the firmware's step list is the single source of truth;
+           nothing here is shown on-device. -->
       <ul class="stepper" id="progress-stepper">
         <li class="step active"><span class="indicator"></span>Connecting to keypad</li>
         <li class="step"><span class="indicator"></span>Discovering services</li>
@@ -634,8 +723,12 @@
               <path d="M10 21l7 7 13-14"/>
             </svg>
           </div>
-          <h2>Paired!</h2>
-          <p class="desc">Your keypad is connected to this bridge.</p>
+          <h2 id="result-success-title">Linked!</h2>
+          <p class="desc" id="result-success-desc">Your keypad is connected to this bridge.</p>
+          <div class="next-step">
+            <strong id="result-next-title">Next: link the physical lock</strong>
+            <span id="result-next-body">Open the Lock tab above to connect the real lock and relay keypad commands.</span>
+          </div>
         </div>
       </div>
 
@@ -649,8 +742,8 @@
               <line x1="28" y1="12" x2="12" y2="28"/>
             </svg>
           </div>
-          <h2>Pairing failed</h2>
-          <p class="desc">Could not complete the BLE handshake.</p>
+          <h2 id="result-error-title">Linking failed</h2>
+          <p class="desc" id="result-error-desc">Could not complete the BLE handshake.</p>
         </div>
 
         <div class="banner banner-error">
@@ -658,11 +751,11 @@
           <span id="error-banner-text">Timed out waiting for the ACK on the finalize command. Move the keypad closer and try again.</span>
         </div>
 
-        <button class="btn btn-primary" onclick="showScreen('keypads')">Try again</button>
+        <button class="btn btn-primary" onclick="retryFromError()">Try again</button>
       </div>
     </div>
 
-    <p class="footnote" id="progress-hint">Pairing takes about 10 seconds.</p>
+    <p class="footnote" id="progress-hint">Linking takes about 10 seconds.</p>
   </section>
 
 </main>
@@ -685,12 +778,91 @@
       next === 'dark' ? '☀️ Light' : '🌙 Dark';
   }
 
+  let currentScreen = 'login';
+  let keypadPaired = false;
+  let lockLinked = false;
+  /* Which job the progress screen is showing ('keypad' | 'lock') — selects
+     the result copy and which tab lights up while the job runs. */
+  let progressKind = 'keypad';
+  /* True while a pair/link job is in flight. Locks tab navigation: kicking
+     off a BLE rescan mid-handshake would disturb the running job's radio
+     work, and there is nothing useful to do elsewhere until it finishes. */
+  let jobActive = false;
+
+  function setKeypadPaired(value) {
+    keypadPaired = !!value;
+    updateSetupTabs(currentScreen);
+  }
+
+  function setLockLinked(value) {
+    lockLinked = !!value;
+    updateSetupTabs(currentScreen);
+  }
+
+  function updateSetupTabs(name) {
+    const tabs = document.getElementById('setup-tabs');
+    const note = document.getElementById('lock-tab-note');
+    const showTabs = name === 'keypads' || name === 'locks' || name === 'progress';
+    tabs.classList.toggle('hidden', !showTabs);
+
+    const keypadTab = document.getElementById('tab-keypads');
+    const lockTab = document.getElementById('tab-locks');
+    const lockActive = name === 'locks' ||
+      (name === 'progress' && progressKind === 'lock');
+    keypadTab.classList.toggle('active', !lockActive);
+    lockTab.classList.toggle('active', lockActive);
+    lockTab.setAttribute('aria-disabled', keypadPaired ? 'false' : 'true');
+
+    const showNote = showTabs && !keypadPaired && name !== 'progress';
+    note.classList.toggle('hidden', !showNote);
+  }
+
+  function showLockGate() {
+    const list = document.getElementById('locks-list');
+    if (list) {
+      list.innerHTML = '<div class="empty-state">Link a keypad first. The lock relay needs the keypad shared key.</div>';
+    }
+    const rescan = document.getElementById('rescan-locks-btn');
+    if (rescan) rescan.disabled = true;
+  }
+
+  /* "Already done" states: pairing and linking are one-shot — redoing either
+     goes through the bridge's Reset button, which also rotates the shared
+     key. The server enforces the same rule with a 409, this is just the
+     friendly face of it. */
+  const RESET_HINT = 'Press the bridge’s Reset button (in Home Assistant) to start over.';
+
+  function showKeypadDone() {
+    document.getElementById('keypads-list').innerHTML =
+      '<div class="empty-state">A keypad is already linked to this bridge.<br>' +
+      RESET_HINT + '</div>';
+    document.getElementById('rescan-btn').disabled = true;
+  }
+
+  function showLockDone() {
+    document.getElementById('locks-list').innerHTML =
+      '<div class="empty-state">A lock is already linked to this bridge.<br>' +
+      RESET_HINT + '</div>';
+    document.getElementById('rescan-locks-btn').disabled = true;
+  }
+
+  function unlockLockControls() {
+    const rescan = document.getElementById('rescan-locks-btn');
+    if (rescan) rescan.disabled = false;
+  }
+
   /* Preview-only screen switcher. The real firmware will use the
      submit handlers / API calls below. */
   function showScreen(name) {
+    currentScreen = name;
     document.querySelectorAll('.screen').forEach(s => s.classList.add('hidden'));
     const el = document.getElementById('screen-' + name);
     if (el) el.classList.remove('hidden');
+    updateSetupTabs(name);
+    if (name === 'locks') {
+      if (!keypadPaired) showLockGate();
+      else if (lockLinked) showLockDone();
+    }
     document.querySelectorAll('.preview-nav button').forEach(b => b.classList.remove('active'));
     const btn = [...document.querySelectorAll('.preview-nav button')]
       .find(b => b.textContent.trim().toLowerCase().includes(name.replace('result-', '').replace(/-/g, ' ')));
@@ -701,10 +873,11 @@
      look. Without this the Progress button would still show whichever result
      (Success / Error) was opened last, since those swap the stepper out. */
   function previewProgress() {
+    progressKind = 'keypad';
     document.getElementById('progress-result-success').classList.add('hidden');
     document.getElementById('progress-result-error').classList.add('hidden');
     document.getElementById('progress-stepper').classList.remove('hidden');
-    setProgressHint('Pairing takes about 10 seconds.');
+    setProgressHint('Linking takes about 10 seconds.');
     const steps = document.querySelectorAll('#progress-stepper .step');
     steps.forEach((li, i) => {
       li.classList.remove('done', 'active');
@@ -714,6 +887,21 @@
     const bar = document.getElementById('progress-bar');
     bar.style.background = 'var(--sb-theme)';
     bar.style.width = Math.round((3 / steps.length) * 100) + '%';
+  }
+
+  function previewLocks() {
+    setKeypadPaired(true);
+    unlockLockControls();
+    const list = document.getElementById('locks-list');
+    if (!list || location.protocol !== 'file:') return;
+    list.innerHTML = '';
+    list.appendChild(renderLockCard({
+      name: 'Front Door Lock',
+      mac: 'B0:E9:FE:11:22:33',
+      model: 'lock_pro',
+      online: true,
+      rssi: -45,
+    }));
   }
 
   /* ── REST helpers ───────────────────────────────────────────────────── */
@@ -750,6 +938,23 @@
 
   /* ── Login ───────────────────────────────────────────────────────────── */
 
+  document.getElementById('tab-keypads').addEventListener('click', () => {
+    if (jobActive) return;
+    showScreen('keypads');
+    loadKeypads();
+  });
+
+  document.getElementById('tab-locks').addEventListener('click', () => {
+    if (jobActive) return;
+    if (!keypadPaired) {
+      showScreen('keypads');
+      return;
+    }
+    unlockLockControls();
+    showScreen('locks');
+    loadLocks();
+  });
+
   document.getElementById('login-form').addEventListener('submit', async (e) => {
     e.preventDefault();
     const fd = new FormData(e.target);
@@ -759,12 +964,21 @@
     btn.textContent = 'Signing in…';
     setBanner('login-error', null);
     try {
-      await api('POST', '/api/login', {
+      const login = await api('POST', '/api/login', {
         email: fd.get('email'),
         password: fd.get('password'),
       });
-      showScreen('keypads');
-      loadKeypads();
+      setKeypadPaired(!!login.keypad_paired);
+      setLockLinked(!!login.lock_linked);
+      // Land on the first incomplete step; with everything done the Keypad
+      // tab shows its completed state.
+      if (keypadPaired && !lockLinked) {
+        showScreen('locks');
+        loadLocks();
+      } else {
+        showScreen('keypads');
+        loadKeypads();
+      }
     } catch (err) {
       const text = document.getElementById('login-error-text');
       if (text) text.textContent = err.message;
@@ -777,27 +991,99 @@
 
   /* ── Keypad list ─────────────────────────────────────────────────────── */
 
-  async function loadKeypads() {
-    // /api/keypads runs a ~8s BLE scan; lock the Rescan button so the user
-    // can't fire concurrent scans by clicking again while one is running.
-    const btn = document.getElementById('rescan-btn');
+  function deviceIcon(kind) {
+    if (kind === 'lock') {
+      return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" ' +
+        'stroke-linecap="round" stroke-linejoin="round">' +
+        '<rect x="5" y="10" width="14" height="10" rx="2"/>' +
+        '<path d="M8 10V7a4 4 0 0 1 8 0v3"/>' +
+        '<path d="M12 14v2"/>' +
+      '</svg>';
+    }
+    return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" ' +
+      'stroke-linecap="round" stroke-linejoin="round">' +
+      '<rect x="4" y="3" width="16" height="18" rx="2.5"/>' +
+      '<circle cx="8"  cy="9"  r="1" fill="currentColor" stroke="none"/>' +
+      '<circle cx="12" cy="9"  r="1" fill="currentColor" stroke="none"/>' +
+      '<circle cx="16" cy="9"  r="1" fill="currentColor" stroke="none"/>' +
+      '<circle cx="8"  cy="13" r="1" fill="currentColor" stroke="none"/>' +
+      '<circle cx="12" cy="13" r="1" fill="currentColor" stroke="none"/>' +
+      '<circle cx="16" cy="13" r="1" fill="currentColor" stroke="none"/>' +
+      '<rect x="7" y="16.5" width="10" height="1.5" rx="0.75" fill="currentColor" stroke="none"/>' +
+    '</svg>';
+  }
+
+  const DEVICE_FLOWS = {
+    keypad: {
+      listId: 'keypads-list',
+      rescanId: 'rescan-btn',
+      listPath: '/api/keypads',
+      startPath: '/api/pair',
+      statusPath: '/api/pair/status',
+      action: 'Link',
+      loading: 'Searching for keypads nearby...',
+      empty: 'No keypads found in your SwitchBot account.',
+      hint: 'Linking takes about 10 seconds.',
+      beforeLoad() {
+        if (keypadPaired) {
+          showKeypadDone();
+          return false;
+        }
+        return true;
+      },
+      payload(device) {
+        return { mac: device.mac, family: device.family };
+      },
+    },
+    lock: {
+      listId: 'locks-list',
+      rescanId: 'rescan-locks-btn',
+      listPath: '/api/locks',
+      startPath: '/api/lock/link',
+      statusPath: '/api/lock/link/status',
+      action: 'Link',
+      loading: 'Searching for locks nearby...',
+      empty: 'No supported locks found in your SwitchBot account.',
+      hint: 'Linking takes about 10 seconds.',
+      beforeLoad() {
+        if (!keypadPaired) {
+          showLockGate();
+          return false;
+        }
+        if (lockLinked) {
+          showLockDone();
+          return false;
+        }
+        unlockLockControls();
+        return true;
+      },
+      payload(device) {
+        return { mac: device.mac };
+      },
+    },
+  };
+
+  async function loadDeviceList(kind) {
+    const flow = DEVICE_FLOWS[kind];
+    if (flow.beforeLoad && !flow.beforeLoad()) return;
+    const btn = document.getElementById(flow.rescanId);
     if (btn.disabled) return;
     btn.disabled = true;
-    const list = document.getElementById('keypads-list');
+    const list = document.getElementById(flow.listId);
     list.innerHTML =
       '<div class="empty-state">' +
         '<div class="spinner"></div>' +
-        'Searching for keypads nearby…' +
+        flow.loading +
       '</div>';
     try {
-      const keypads = await api('GET', '/api/keypads');
-      if (!Array.isArray(keypads) || keypads.length === 0) {
-        list.innerHTML = '<div class="empty-state">No keypads found in your SwitchBot account.</div>';
+      const devices = await api('GET', flow.listPath);
+      if (!Array.isArray(devices) || devices.length === 0) {
+        list.innerHTML = '<div class="empty-state">' + flow.empty + '</div>';
         return;
       }
       list.innerHTML = '';
-      for (const kp of keypads) {
-        list.appendChild(renderKeypadCard(kp));
+      for (const device of devices) {
+        list.appendChild(renderDeviceCard(kind, device));
       }
     } catch (err) {
       list.innerHTML = '<div class="empty-state">Error: ' + escapeHtml(err.message) + '</div>';
@@ -806,95 +1092,116 @@
     }
   }
 
-  function renderKeypadCard(kp) {
+  function renderDeviceCard(kind, device) {
+    const flow = DEVICE_FLOWS[kind];
     const card = document.createElement('div');
-    const offline = !kp.online;
+    const offline = !device.online;
     card.className = 'kp-card' + (offline ? '' : ' online');
-    const rssiLabel = kp.rssi != null ? '−' + Math.abs(kp.rssi) + ' dBm' : 'Nearby';
+    const rssiLabel = device.rssi != null ? '-' + Math.abs(device.rssi) + ' dBm' : 'Nearby';
     const badgeClass = offline ? 'offline' : 'online';
     const badgeText = offline ? 'Out of range' : rssiLabel;
-    const kpSvg =
-      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" ' +
-        'stroke-linecap="round" stroke-linejoin="round">' +
-        '<rect x="4" y="3" width="16" height="18" rx="2.5"/>' +
-        '<circle cx="8"  cy="9"  r="1" fill="currentColor" stroke="none"/>' +
-        '<circle cx="12" cy="9"  r="1" fill="currentColor" stroke="none"/>' +
-        '<circle cx="16" cy="9"  r="1" fill="currentColor" stroke="none"/>' +
-        '<circle cx="8"  cy="13" r="1" fill="currentColor" stroke="none"/>' +
-        '<circle cx="12" cy="13" r="1" fill="currentColor" stroke="none"/>' +
-        '<circle cx="16" cy="13" r="1" fill="currentColor" stroke="none"/>' +
-        '<rect x="7" y="16.5" width="10" height="1.5" rx="0.75" fill="currentColor" stroke="none"/>' +
-      '</svg>';
     card.innerHTML =
-      '<div class="kp-icon' + (offline ? ' dim' : '') + '">' + kpSvg + '</div>' +
+      '<div class="kp-icon' + (offline ? ' dim' : '') + '">' + deviceIcon(kind) + '</div>' +
       '<div class="kp-info">' +
-        '<div class="kp-name">' + escapeHtml(kp.name) + '</div>' +
+        '<div class="kp-name">' + escapeHtml(device.name) + '</div>' +
         '<div class="kp-meta">' +
-          '<span class="kp-mac">' + escapeHtml(kp.mac) + '</span>' +
+          '<span class="kp-mac">' + escapeHtml(device.mac) + '</span>' +
           '<span class="kp-badge ' + badgeClass + '"><span class="dot"></span>' + escapeHtml(badgeText) + '</span>' +
         '</div>' +
       '</div>' +
-      '<button class="btn-pair"' + (offline ? ' disabled' : '') + '>Pair</button>';
+      '<button class="btn-pair"' + (offline ? ' disabled' : '') + '>' + flow.action + '</button>';
     card.querySelector('.btn-pair').addEventListener('click', () => {
-      if (offline) return;
-      startPair(kp);
+      if (!offline) startDeviceJob(kind, device);
     });
     return card;
   }
 
-  document.getElementById('rescan-btn').addEventListener('click', loadKeypads);
-
-  /* ── Pairing job ─────────────────────────────────────────────────────── */
-
-  let currentKp = null;
-
-  async function startPair(kp) {
-    currentKp = kp;
-    /* The real step list (labels) comes from the firmware in the /api/pair
-       response — never duplicated here. Until it arrives, show a loader so the
-       card is never empty; it's swapped for the real steps on response. */
-    const stepper = document.getElementById('progress-stepper');
-    stepper.classList.add('loading');
-    stepper.innerHTML = '<li class="stepper-loader"><span class="spinner"></span></li>';
-    showScreen('progress');
-    document.getElementById('progress-kp-name').textContent = kp.name;
-    document.getElementById('progress-kp-mac').textContent = kp.mac;
-    document.getElementById('progress-bar').style.width = '0%';
-    document.getElementById('progress-bar').style.background = 'var(--sb-theme)';
-    
-    // Reset view to Stepper mode inside the card
-    document.getElementById('progress-stepper').classList.remove('hidden');
-    document.getElementById('progress-result-success').classList.add('hidden');
-    document.getElementById('progress-result-error').classList.add('hidden');
-    setProgressHint('Pairing takes about 10 seconds.');
-
+  async function startDeviceJob(kind, device) {
+    const flow = DEVICE_FLOWS[kind];
+    beginProgress(kind, device.name, device.mac, flow.hint);
     let jobId;
     try {
-      const r = await api('POST', '/api/pair', { mac: kp.mac, family: kp.family });
+      const r = await api('POST', flow.startPath, flow.payload(device));
       jobId = r.job_id;
-      /* Fill the stepper from the firmware's own step list — the single source
-         of truth for the steps, their count, order and wording. The per-item
-         animation-delay staggers the fade-in so the list eases in. */
-      if (Array.isArray(r.labels) && r.labels.length) {
-        stepper.classList.remove('loading');
-        stepper.innerHTML = r.labels.map((l, i) =>
-          '<li class="step" style="animation-delay:' + (i * 55) + 'ms">' +
-          '<span class="indicator"></span>' + escapeHtml(l) + '</li>'
-        ).join('');
-      }
+      fillStepper(r.labels);
     } catch (err) {
       showResultError(err.message);
       return;
     }
-    pollPair(jobId);
+    pollJob(flow.statusPath, jobId);
   }
 
-  async function pollPair(jobId) {
+  async function loadKeypads() {
+    return loadDeviceList('keypad');
+  }
+
+  function renderKeypadCard(kp) {
+    return renderDeviceCard('keypad', kp);
+  }
+
+  document.getElementById('rescan-btn').addEventListener('click', loadKeypads);
+
+  async function loadLocks() {
+    return loadDeviceList('lock');
+  }
+
+  function renderLockCard(lock) {
+    return renderDeviceCard('lock', lock);
+  }
+
+  document.getElementById('rescan-locks-btn').addEventListener('click', loadLocks);
+
+  /* ── Background jobs (keypad linking & lock linking) ─────────────────── */
+
+  /* Reset the shared progress screen for a new job: header, bar, and a
+     loading stepper until the firmware returns its step labels. */
+  function beginProgress(kind, name, mac, hint) {
+    progressKind = kind;
+    jobActive = true;
+    const stepper = document.getElementById('progress-stepper');
+    stepper.classList.add('loading');
+    stepper.innerHTML = '<li class="stepper-loader"><span class="spinner"></span></li>';
+    showScreen('progress');
+    document.getElementById('progress-kp-name').textContent = name;
+    document.getElementById('progress-kp-mac').textContent = mac;
+    const bar = document.getElementById('progress-bar');
+    bar.style.width = '0%';
+    bar.style.background = 'var(--sb-theme)';
+
+    // Reset view to Stepper mode inside the card
+    stepper.classList.remove('hidden');
+    document.getElementById('progress-result-success').classList.add('hidden');
+    document.getElementById('progress-result-error').classList.add('hidden');
+    setProgressHint(hint);
+  }
+
+  /* Fill the stepper from the firmware's own step list — the single source
+     of truth for the steps, their count, order and wording. The per-item
+     animation-delay staggers the fade-in so the list eases in. */
+  function fillStepper(labels) {
+    if (!Array.isArray(labels) || !labels.length) return;
+    const stepper = document.getElementById('progress-stepper');
+    stepper.classList.remove('loading');
+    stepper.innerHTML = labels.map((l, i) =>
+      '<li class="step" style="animation-delay:' + (i * 55) + 'ms">' +
+      '<span class="indicator"></span>' + escapeHtml(l) + '</li>'
+    ).join('');
+  }
+
+  async function startPair(kp) {
+    return startDeviceJob('keypad', kp);
+  }
+
+  async function startLinkLock(lock) {
+    return startDeviceJob('lock', lock);
+  }
+
+  async function pollJob(statusPath, jobId) {
     while (true) {
       await new Promise(r => setTimeout(r, 500));
       let status;
       try {
-        status = await api('GET', '/api/pair/status?job_id=' + encodeURIComponent(jobId));
+        status = await api('GET', statusPath + '?job_id=' + encodeURIComponent(jobId));
       } catch (err) {
         showResultError(err.message);
         return;
@@ -916,9 +1223,9 @@
     }
   }
 
-  /* The footnote under the progress card: a state hint while pairing runs,
-     the "you can close this" note on success, hidden on error (the in-card
-     error banner carries that detail instead). Pass null to hide it. */
+  /* The footnote under the progress card: a state hint while a job runs,
+     the next-step hint on success, hidden on error (the in-card error
+     banner carries that detail instead). Pass null to hide it. */
   function setProgressHint(text) {
     const el = document.getElementById('progress-hint');
     if (text === null) {
@@ -929,16 +1236,53 @@
     el.classList.remove('hidden');
   }
 
+  /* Per-job copy for the shared result screens — keypad linking and lock
+     linking render into the same success/error heroes. */
+  const RESULT_COPY = {
+    keypad: {
+      successTitle: 'Linked!',
+      successDesc: 'Your keypad is connected to this bridge.',
+      nextTitle: 'Next: link the physical lock',
+      nextBody: 'Open the Lock tab above to connect the real lock and relay keypad commands.',
+      successHint: 'Open the Lock tab above to link the physical lock.',
+      errorTitle: 'Linking failed',
+      errorDesc: 'Could not complete the BLE handshake.',
+      retry: () => { showScreen('keypads'); loadKeypads(); },
+    },
+    lock: {
+      successTitle: 'Linked!',
+      successDesc: 'Your lock now takes its keypad commands through this bridge.',
+      nextTitle: 'Setup complete',
+      nextBody: 'You can close this page — the setup server shuts down automatically after a few minutes of inactivity.',
+      successHint: null,
+      errorTitle: 'Linking failed',
+      errorDesc: 'Could not verify the lock over BLE.',
+      retry: () => { showScreen('locks'); loadLocks(); },
+    },
+  };
+
   function showResultSuccess() {
+    jobActive = false;
+    const copy = RESULT_COPY[progressKind];
+    if (progressKind === 'lock') setLockLinked(true);
+    else setKeypadPaired(true);
+    document.getElementById('result-success-title').textContent = copy.successTitle;
+    document.getElementById('result-success-desc').textContent = copy.successDesc;
+    document.getElementById('result-next-title').textContent = copy.nextTitle;
+    document.getElementById('result-next-body').textContent = copy.nextBody;
     document.getElementById('progress-stepper').classList.add('hidden');
-    setProgressHint('You can close this page — the pairing server shuts down automatically.');
+    setProgressHint(copy.successHint);
     document.getElementById('progress-result-error').classList.add('hidden');
     document.getElementById('progress-result-success').classList.remove('hidden');
     document.getElementById('progress-bar').style.width = '100%';
     document.getElementById('progress-bar').style.background = 'var(--sb-success)';
   }
-  
+
   function showResultError(msg) {
+    jobActive = false;
+    const copy = RESULT_COPY[progressKind];
+    document.getElementById('result-error-title').textContent = copy.errorTitle;
+    document.getElementById('result-error-desc').textContent = copy.errorDesc;
     document.getElementById('progress-stepper').classList.add('hidden');
     setProgressHint(null);
     document.getElementById('progress-result-success').classList.add('hidden');
@@ -948,6 +1292,10 @@
 
     const banner = document.getElementById('error-banner-text');
     if (banner) banner.textContent = msg;
+  }
+
+  function retryFromError() {
+    RESULT_COPY[progressKind].retry();
   }
 </script>
 </body>

--- a/components/switchbot_keypad_bridge/physical_lock.cpp
+++ b/components/switchbot_keypad_bridge/physical_lock.cpp
@@ -1,0 +1,611 @@
+#include "physical_lock.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "aes_ctr.h"
+#include "ble_utils.h"
+#include "mac_utils.h"
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+namespace {
+
+const char *const TAG = "switchbot_keypad_bridge.lock";
+
+constexpr uint8_t PROTOCOL_MAGIC = 0x57;
+constexpr size_t WIRE_HEADER_LEN = 4;
+
+struct NotifyWaiter {
+  SemaphoreHandle_t sem{nullptr};
+  std::string value;
+};
+
+bool wait_notify(NotifyWaiter &waiter, uint32_t timeout_ms, std::string &out) {
+  if (xSemaphoreTake(waiter.sem, pdMS_TO_TICKS(timeout_ms)) != pdTRUE) {
+    return false;
+  }
+  out = waiter.value;
+  return true;
+}
+
+// Rebuild a connectable address from the bare MAC the cloud stores. The BLE
+// spec fixes the two most significant bits of a static random address to 11;
+// anything else (like SwitchBot's public B0:E9:FE OUI) is a public address.
+// A wrong guess only costs the discovery-scan fallback in connect_().
+NimBLEAddress address_from_mac(const std::string &mac_pretty) {
+  const std::string mac = upper_mac(mac_pretty);
+  const uint8_t msb =
+      static_cast<uint8_t>(std::strtol(mac.substr(0, 2).c_str(), nullptr, 16));
+  const uint8_t type = ((msb & 0xC0) == 0xC0) ? BLE_ADDR_RANDOM : BLE_ADDR_PUBLIC;
+  return NimBLEAddress(mac, type);
+}
+
+NimBLEAddress discover_target(const std::string &mac_pretty, uint32_t timeout_ms) {
+  NimBLEScan *scan = NimBLEDevice::getScan();
+  configure_switchbot_scan(scan);
+  const std::string target = upper_mac(mac_pretty);
+
+  NimBLEScanResults results = scan->getResults(timeout_ms, false);
+  for (int i = 0; i < results.getCount(); ++i) {
+    const NimBLEAdvertisedDevice *adv = results.getDevice(i);
+    if (upper_mac(adv->getAddress().toString()) == target) {
+      ESP_LOGI(TAG, "Found lock %s (addr_type=%d, rssi=%d)",
+               mac_pretty.c_str(), adv->getAddressType(), adv->getRSSI());
+      return adv->getAddress();
+    }
+  }
+  return NimBLEAddress{};
+}
+
+const uint8_t *lock_info_plaintext(PhysicalLockModel model, size_t &len) {
+  static constexpr uint8_t ORIGINAL[] = {0x0F, 0x4F, 0x81, 0x01};
+  static constexpr uint8_t PRO[]      = {0x0F, 0x4F, 0x81, 0x04};
+  static constexpr uint8_t ULTRA[]    = {0x0F, 0x4F, 0x81, 0x07};
+  static constexpr uint8_t VISION[]   = {0x0F, 0x4F, 0x81, 0x02};
+  static constexpr uint8_t PRO_WIFI[] = {0x0F, 0x4F, 0x81, 0x0A};
+
+  switch (model) {
+    case PhysicalLockModel::LOCK:
+    case PhysicalLockModel::LOCK_LITE:
+      len = sizeof(ORIGINAL);
+      return ORIGINAL;
+    case PhysicalLockModel::LOCK_PRO:
+      len = sizeof(PRO);
+      return PRO;
+    case PhysicalLockModel::LOCK_ULTRA:
+      len = sizeof(ULTRA);
+      return ULTRA;
+    case PhysicalLockModel::LOCK_VISION:
+    case PhysicalLockModel::LOCK_VISION_PRO:
+      len = sizeof(VISION);
+      return VISION;
+    case PhysicalLockModel::LOCK_PRO_WIFI:
+      len = sizeof(PRO_WIFI);
+      return PRO_WIFI;
+    default:
+      len = 0;
+      return nullptr;
+  }
+}
+
+uint8_t normalize_mode_byte(uint8_t mode_byte) {
+  // pySwitchbot treats 0 as CTR and 1 as GCM. Some captures use non-zero
+  // feature bits around the low mode bit; keep this tolerant.
+  return mode_byte & 0x01;
+}
+
+void increment_gcm_iv(std::array<uint8_t, 12> &iv) {
+  for (int i = static_cast<int>(iv.size()) - 1; i >= 0; --i) {
+    if (++iv[static_cast<size_t>(i)] != 0) break;
+  }
+}
+
+}  // namespace
+
+const char *physical_lock_model_str(PhysicalLockModel model) {
+  switch (model) {
+    case PhysicalLockModel::LOCK:
+      return "lock";
+    case PhysicalLockModel::LOCK_LITE:
+      return "lock_lite";
+    case PhysicalLockModel::LOCK_PRO:
+      return "lock_pro";
+    case PhysicalLockModel::LOCK_ULTRA:
+      return "lock_ultra";
+    case PhysicalLockModel::LOCK_VISION:
+      return "lock_vision";
+    case PhysicalLockModel::LOCK_VISION_PRO:
+      return "lock_vision_pro";
+    case PhysicalLockModel::LOCK_PRO_WIFI:
+      return "lock_pro_wifi";
+    default:
+      return "unknown";
+  }
+}
+
+PhysicalLockModel physical_lock_model_from_api_type(const std::string &device_type) {
+  if (device_type == "WoLock") return PhysicalLockModel::LOCK;
+  if (device_type == "WoLockLite") return PhysicalLockModel::LOCK_LITE;
+  if (device_type == "WoLockPro") return PhysicalLockModel::LOCK_PRO;
+  if (device_type == "W1091000") return PhysicalLockModel::LOCK_ULTRA;
+  if (device_type == "W1141000") return PhysicalLockModel::LOCK_VISION;
+  if (device_type == "W1141001") return PhysicalLockModel::LOCK_VISION_PRO;
+  if (device_type == "W1114000") return PhysicalLockModel::LOCK_PRO_WIFI;
+  return PhysicalLockModel::UNKNOWN;
+}
+
+bool is_supported_physical_lock_type(const std::string &device_type) {
+  return physical_lock_model_from_api_type(device_type) != PhysicalLockModel::UNKNOWN;
+}
+
+bool lock_status_byte_plausible(PhysicalLockModel model, uint8_t state) {
+  switch (model) {
+    case PhysicalLockModel::LOCK:
+    case PhysicalLockModel::LOCK_LITE:
+    case PhysicalLockModel::LOCK_VISION:
+    case PhysicalLockModel::LOCK_VISION_PRO:
+      return ((state & 0x70) >> 4) <= 6;
+    case PhysicalLockModel::LOCK_PRO:
+    case PhysicalLockModel::LOCK_ULTRA:
+    case PhysicalLockModel::LOCK_PRO_WIFI:
+      return ((state & 0x78) >> 3) <= 6;
+    default:
+      return false;
+  }
+}
+
+bool lock_info_response_plausible(PhysicalLockModel model,
+                                  const std::vector<uint8_t> &response) {
+  if (response.empty()) {
+    return false;
+  }
+
+  // Keypad-side state poll replies have a stable 14-byte shape in captures:
+  // <state> 08 <rolling> 41 00 00 00 00 80 <ctx0> <ctx1> 00 00 00.
+  if (response.size() == 14 && response[1] == 0x08 && response[3] == 0x41 &&
+      response[8] == 0x80) {
+    return lock_status_byte_plausible(PhysicalLockModel::LOCK, response[0]);
+  }
+
+  // App-style lock-info replies are model-dependent. For example, a Lock
+  // Ultra answering 0F 4F 81 07 returns a 16-byte payload such as
+  // B2 00 26 00 81 00 0B F8 ...; pySwitchbot treats the encrypted wire-status
+  // byte as the command result and parses this decrypted payload as lock data.
+  return response.size() >= 6 && lock_status_byte_plausible(model, response[0]);
+}
+
+bool PhysicalLockClient::verify(const Config &config, std::string &error_out,
+                                const ProgressCallback &progress) {
+  size_t len = 0;
+  const uint8_t *cmd = lock_info_plaintext(config.model, len);
+  if (cmd == nullptr || len == 0) {
+    error_out = "Unsupported SwitchBot Lock model.";
+    return false;
+  }
+  std::vector<uint8_t> response;
+  if (!this->send_plaintext(config, cmd, len, response, error_out, progress)) {
+    return false;
+  }
+  if (response.empty()) {
+    error_out = "Shared key verified but no lock-info payload was returned.";
+    return false;
+  }
+  if (!lock_info_response_plausible(config.model, response)) {
+    error_out = "The lock answered, but the shared-key lock-info payload was not valid.";
+    return false;
+  }
+  return true;
+}
+
+bool PhysicalLockClient::send_plaintext(const Config &config, const uint8_t *plaintext,
+                                        size_t plaintext_len,
+                                        std::vector<uint8_t> &response_plaintext,
+                                        std::string &error_out,
+                                        const ProgressCallback &progress,
+                                        const ResponseCallback &response_callback) {
+  response_plaintext.clear();
+  if (plaintext == nullptr || plaintext_len == 0) {
+    error_out = "Empty lock command.";
+    return false;
+  }
+
+  std::vector<std::vector<uint8_t>> commands = {
+      std::vector<uint8_t>(plaintext, plaintext + plaintext_len)};
+  std::vector<std::vector<uint8_t>> responses;
+  if (!this->send_plaintext_sequence(config, commands, responses, error_out,
+                                     progress, response_callback)) {
+    return false;
+  }
+  if (!responses.empty()) {
+    response_plaintext = std::move(responses.front());
+  }
+  return true;
+}
+
+bool PhysicalLockClient::send_plaintext_sequence(
+    const Config &config,
+    const std::vector<std::vector<uint8_t>> &commands,
+    std::vector<std::vector<uint8_t>> &responses,
+    std::string &error_out,
+    const ProgressCallback &progress,
+    const ResponseCallback &response_callback) {
+  responses.clear();
+  if (commands.empty()) {
+    error_out = "Empty lock command sequence.";
+    return false;
+  }
+  for (const auto &cmd : commands) {
+    if (cmd.empty()) {
+      error_out = "Empty lock command in sequence.";
+      return false;
+    }
+  }
+
+  NimBLEClient *client = nullptr;
+  NimBLERemoteCharacteristic *rx = nullptr;
+  NimBLERemoteCharacteristic *tx = nullptr;
+  if (!this->connect_(config, client, rx, tx, error_out, progress)) {
+    return false;
+  }
+
+  NotifyWaiter waiter;
+  waiter.sem = xSemaphoreCreateBinary();
+  if (waiter.sem == nullptr) {
+    client->disconnect();
+    NimBLEDevice::deleteClient(client);
+    error_out = "Could not allocate lock notification semaphore.";
+    return false;
+  }
+
+  if (!tx->subscribe(true,
+                     [&waiter](NimBLERemoteCharacteristic *, uint8_t *data,
+                               size_t length, bool /*is_notify*/) {
+                       waiter.value.assign(reinterpret_cast<const char *>(data), length);
+                       xSemaphoreGive(waiter.sem);
+                     })) {
+    vSemaphoreDelete(waiter.sem);
+    client->disconnect();
+    NimBLEDevice::deleteClient(client);
+    error_out = "Could not subscribe to lock notifications.";
+    return false;
+  }
+
+  bool ok = false;
+  Session session;
+  std::string notify;
+  if (progress) progress(Phase::SESSION);
+  uint8_t iv_req[8] = {PROTOCOL_MAGIC, 0x00, 0x00, 0x00, 0x0F, 0x21, 0x03, config.key_id};
+  if (!rx->writeValue(iv_req, sizeof(iv_req), /*response=*/true)) {
+    error_out = "Could not request a lock encryption session.";
+  } else if (!wait_notify(waiter, 3000, notify)) {
+    error_out = "Lock did not open an encryption session.";
+  } else if (this->parse_session_response_(notify, session, error_out)) {
+    ok = true;
+    for (const auto &cmd : commands) {
+      if (progress) progress(Phase::COMMAND);
+      if (!this->send_encrypted_(config, session, rx, cmd.data(), cmd.size(), error_out)) {
+        ok = false;
+        break;
+      }
+      if (!wait_notify(waiter, 2500, notify)) {
+        error_out = "Lock did not answer the forwarded command.";
+        ok = false;
+        break;
+      } else {
+        std::vector<uint8_t> response;
+        ok = this->decrypt_notify_(config, session, notify, response, error_out);
+        if (!ok) {
+          break;
+        }
+        if (response_callback) {
+          response_callback(response);
+        }
+        responses.push_back(std::move(response));
+      }
+    }
+  }
+
+  tx->unsubscribe();
+  vSemaphoreDelete(waiter.sem);
+  client->disconnect();
+  NimBLEDevice::deleteClient(client);
+  return ok;
+}
+
+bool PhysicalLockClient::provision_and_verify_shared_key(
+    const Config &provisioning_config,
+    const std::vector<std::vector<uint8_t>> &provision_commands,
+    std::vector<std::vector<uint8_t>> &provision_responses,
+    const Config &shared_config,
+    std::string &error_out,
+    const ProgressCallback &provision_progress,
+    const CommandProgressCallback &provision_command_progress,
+    const ProgressCallback &verify_progress) {
+  provision_responses.clear();
+  if (provision_commands.empty()) {
+    error_out = "Empty lock provisioning command sequence.";
+    return false;
+  }
+  for (const auto &cmd : provision_commands) {
+    if (cmd.empty()) {
+      error_out = "Empty lock provisioning command.";
+      return false;
+    }
+  }
+
+  size_t verify_len = 0;
+  const uint8_t *verify_cmd = lock_info_plaintext(shared_config.model, verify_len);
+  if (verify_cmd == nullptr || verify_len == 0) {
+    error_out = "Unsupported SwitchBot Lock model.";
+    return false;
+  }
+
+  NimBLEClient *client = nullptr;
+  NimBLERemoteCharacteristic *rx = nullptr;
+  NimBLERemoteCharacteristic *tx = nullptr;
+  if (!this->connect_(provisioning_config, client, rx, tx, error_out,
+                      provision_progress)) {
+    return false;
+  }
+
+  NotifyWaiter waiter;
+  waiter.sem = xSemaphoreCreateBinary();
+  if (waiter.sem == nullptr) {
+    client->disconnect();
+    NimBLEDevice::deleteClient(client);
+    error_out = "Could not allocate lock notification semaphore.";
+    return false;
+  }
+
+  if (!tx->subscribe(true,
+                     [&waiter](NimBLERemoteCharacteristic *, uint8_t *data,
+                               size_t length, bool /*is_notify*/) {
+                       waiter.value.assign(reinterpret_cast<const char *>(data), length);
+                       xSemaphoreGive(waiter.sem);
+                     })) {
+    vSemaphoreDelete(waiter.sem);
+    client->disconnect();
+    NimBLEDevice::deleteClient(client);
+    error_out = "Could not subscribe to lock notifications.";
+    return false;
+  }
+
+  auto run_session =
+      [&](const Config &config, const char *session_name,
+          const std::vector<std::vector<uint8_t>> &commands,
+          std::vector<std::vector<uint8_t>> &responses,
+          const ProgressCallback &progress,
+          const CommandProgressCallback &command_progress) -> bool {
+    responses.clear();
+    Session session;
+    std::string notify;
+    if (progress) progress(Phase::SESSION);
+    uint8_t iv_req[8] = {PROTOCOL_MAGIC, 0x00, 0x00, 0x00,
+                         0x0F, 0x21, 0x03, config.key_id};
+    if (!rx->writeValue(iv_req, sizeof(iv_req), /*response=*/true)) {
+      error_out = std::string("Could not request a ") + session_name +
+                  " encryption session.";
+      return false;
+    }
+    if (!wait_notify(waiter, 3000, notify)) {
+      error_out = std::string("Lock did not open the ") + session_name +
+                  " encryption session.";
+      return false;
+    }
+    if (!this->parse_session_response_(notify, session, error_out)) {
+      return false;
+    }
+
+    for (size_t i = 0; i < commands.size(); ++i) {
+      const auto &cmd = commands[i];
+      if (command_progress) {
+        command_progress(i);
+      } else if (progress) {
+        progress(Phase::COMMAND);
+      }
+      if (!this->send_encrypted_(config, session, rx, cmd.data(), cmd.size(),
+                                 error_out)) {
+        return false;
+      }
+      if (!wait_notify(waiter, 2500, notify)) {
+        error_out = "Lock did not answer the forwarded command.";
+        return false;
+      }
+      std::vector<uint8_t> response;
+      if (!this->decrypt_notify_(config, session, notify, response, error_out)) {
+        return false;
+      }
+      responses.push_back(std::move(response));
+    }
+    return true;
+  };
+
+  bool ok = run_session(provisioning_config, "lock provisioning",
+                        provision_commands, provision_responses,
+                        provision_progress, provision_command_progress);
+  if (ok) {
+    std::vector<std::vector<uint8_t>> verify_commands = {
+        std::vector<uint8_t>(verify_cmd, verify_cmd + verify_len)};
+    std::vector<std::vector<uint8_t>> verify_responses;
+    ok = run_session(shared_config, "shared-key verification",
+                     verify_commands, verify_responses,
+                     verify_progress, nullptr);
+    if (ok) {
+      if (verify_responses.empty() || verify_responses.front().empty()) {
+        error_out = "Shared key verified but no lock-info payload was returned.";
+        ok = false;
+      } else if (!lock_info_response_plausible(shared_config.model,
+                                               verify_responses.front())) {
+        error_out = "The lock answered, but the shared-key lock-info payload was not valid.";
+        ok = false;
+      }
+    }
+  }
+
+  tx->unsubscribe();
+  vSemaphoreDelete(waiter.sem);
+  client->disconnect();
+  NimBLEDevice::deleteClient(client);
+  return ok;
+}
+
+bool PhysicalLockClient::connect_(const Config &config, NimBLEClient *&client,
+                                  NimBLERemoteCharacteristic *&rx,
+                                  NimBLERemoteCharacteristic *&tx,
+                                  std::string &error_out,
+                                  const ProgressCallback &progress) {
+  // Two attempts at most: the first connects straight to the last cached
+  // advertisement address — or, fresh after boot, to the address rebuilt
+  // from the stored MAC — skipping the ~2.5 s discovery scan entirely. Only
+  // if that direct connect fails does the second attempt fall back to a scan.
+  for (int attempt = 0; attempt < 2; ++attempt) {
+    NimBLEAddress target;
+    if (attempt == 0) {
+      const bool cache_ok =
+          !this->cached_mac_.empty() && this->cached_mac_ == config.mac;
+      target = cache_ok ? this->cached_addr_ : address_from_mac(config.mac);
+    } else {
+      if (progress) progress(Phase::SCAN);
+      target = discover_target(config.mac, 2500);
+      if (target.isNull()) {
+        error_out = "Could not see the lock over BLE. Keep it near the bridge and retry.";
+        return false;
+      }
+    }
+
+    if (progress) progress(Phase::CONNECT);
+    SwitchbotGattConnection conn;
+    if (!connect_switchbot_service(target, 5000, "physical lock", conn, error_out)) {
+      if (attempt == 0) {
+        this->cached_mac_.clear();  // direct connect failed — scan for real
+        continue;
+      }
+      return false;
+    }
+
+    if (progress) progress(Phase::DISCOVER);
+    client = conn.client;
+    rx = conn.rx;
+    tx = conn.tx;
+    this->cached_addr_ = target;
+    this->cached_mac_  = config.mac;
+    return true;
+  }
+  error_out = "Could not connect to the physical lock.";
+  return false;
+}
+
+bool PhysicalLockClient::parse_session_response_(const std::string &wire,
+                                                 Session &session,
+                                                 std::string &error_out) {
+  if (wire.size() < WIRE_HEADER_LEN || static_cast<uint8_t>(wire[0]) != 0x01) {
+    error_out = "Lock returned a malformed encryption-session response.";
+    return false;
+  }
+  const uint8_t *data = reinterpret_cast<const uint8_t *>(wire.data());
+  const uint8_t mode = normalize_mode_byte(data[2]);
+  if (mode == 1) {
+    if (wire.size() < 20) {
+      error_out = "Lock returned a short AES-GCM IV.";
+      return false;
+    }
+    session.mode = CryptoMode::GCM;
+    std::memcpy(session.gcm_iv.data(), data + WIRE_HEADER_LEN, session.gcm_iv.size());
+    ESP_LOGD(TAG, "Lock encryption session: AES-GCM");
+    return true;
+  }
+  if (wire.size() < WIRE_HEADER_LEN + session.ctr_iv.size()) {
+    error_out = "Lock returned a short AES-CTR IV.";
+    return false;
+  }
+  session.mode = CryptoMode::CTR;
+  std::memcpy(session.ctr_iv.data(), data + WIRE_HEADER_LEN, session.ctr_iv.size());
+  ESP_LOGD(TAG, "Lock encryption session: AES-CTR");
+  return true;
+}
+
+bool PhysicalLockClient::send_encrypted_(const Config &config, const Session &session,
+                                         NimBLERemoteCharacteristic *rx,
+                                         const uint8_t *plaintext,
+                                         size_t plaintext_len,
+                                         std::string &error_out) {
+  std::vector<uint8_t> frame(WIRE_HEADER_LEN + plaintext_len);
+  frame[0] = PROTOCOL_MAGIC;
+  frame[1] = config.key_id;
+
+  if (session.mode == CryptoMode::GCM) {
+    uint8_t tag[16];
+    if (!aes_gcm_encrypt_raw_key(config.key.data(), session.gcm_iv.data(),
+                                 plaintext, frame.data() + WIRE_HEADER_LEN,
+                                 plaintext_len, tag)) {
+      error_out = "Could not encrypt lock command with AES-GCM.";
+      return false;
+    }
+    frame[2] = tag[0];
+    frame[3] = tag[1];
+  } else {
+    frame[2] = session.ctr_iv[0];
+    frame[3] = session.ctr_iv[1];
+    if (!aes_ctr_xcrypt_raw_key(config.key.data(), session.ctr_iv.data(),
+                                plaintext, frame.data() + WIRE_HEADER_LEN,
+                                plaintext_len)) {
+      error_out = "Could not encrypt lock command with AES-CTR.";
+      return false;
+    }
+  }
+
+  ESP_LOGV(TAG, "TX lock %s",
+           format_hex_pretty(frame.data(), frame.size()).c_str());
+  if (!rx->writeValue(frame.data(), frame.size(), /*response=*/true)) {
+    error_out = "Could not write encrypted command to the lock.";
+    return false;
+  }
+  return true;
+}
+
+bool PhysicalLockClient::decrypt_notify_(const Config &config, const Session &session,
+                                         const std::string &wire,
+                                         std::vector<uint8_t> &out,
+                                         std::string &error_out) {
+  if (wire.size() < WIRE_HEADER_LEN) {
+    error_out = "Lock returned a malformed notification.";
+    return false;
+  }
+  const uint8_t *data = reinterpret_cast<const uint8_t *>(wire.data());
+  ESP_LOGV(TAG, "RX lock %s", format_hex_pretty(data, wire.size()).c_str());
+  const size_t payload_len = wire.size() - WIRE_HEADER_LEN;
+  out.resize(payload_len);
+  if (payload_len == 0) {
+    return true;
+  }
+
+  if (session.mode == CryptoMode::GCM) {
+    std::array<uint8_t, 12> iv = session.gcm_iv;
+    increment_gcm_iv(iv);
+    if (!aes_gcm_decrypt_raw_key(config.key.data(), iv.data(),
+                                 data + WIRE_HEADER_LEN, out.data(), payload_len)) {
+      error_out = "Could not decrypt lock response with AES-GCM.";
+      return false;
+    }
+  } else {
+    if (!aes_ctr_xcrypt_raw_key(config.key.data(), session.ctr_iv.data(),
+                                data + WIRE_HEADER_LEN, out.data(), payload_len)) {
+      error_out = "Could not decrypt lock response with AES-CTR.";
+      return false;
+    }
+  }
+  ESP_LOGV(TAG, "RX lock plaintext %s",
+           format_hex_pretty(out.data(), out.size()).c_str());
+  return true;
+}
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/physical_lock.h
+++ b/components/switchbot_keypad_bridge/physical_lock.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include "nimble_compat.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+enum class PhysicalLockModel : uint8_t {
+  UNKNOWN = 0,
+  LOCK,
+  LOCK_LITE,
+  LOCK_PRO,
+  LOCK_ULTRA,
+  LOCK_VISION,
+  LOCK_VISION_PRO,
+  LOCK_PRO_WIFI,
+};
+
+const char *physical_lock_model_str(PhysicalLockModel model);
+PhysicalLockModel physical_lock_model_from_api_type(const std::string &device_type);
+bool is_supported_physical_lock_type(const std::string &device_type);
+
+class PhysicalLockClient {
+ public:
+  struct Config {
+    std::string mac;
+    PhysicalLockModel model{PhysicalLockModel::UNKNOWN};
+    uint8_t key_id{0};
+    std::array<uint8_t, 16> key{};
+  };
+
+  // Coarse progress of one encrypted exchange, reported through the optional
+  // callback below. Callers map these phases to their own user-facing steps.
+  enum class Phase : uint8_t {
+    SCAN = 0,
+    CONNECT,
+    DISCOVER,
+    SESSION,
+    COMMAND,
+  };
+  using ProgressCallback = std::function<void(Phase)>;
+  using CommandProgressCallback = std::function<void(size_t command_index)>;
+  using ResponseCallback = std::function<void(const std::vector<uint8_t> &response)>;
+
+  // Verify that the configured key/slot can open an encrypted BLE session and
+  // return a plausible lock-info payload.
+  bool verify(const Config &config, std::string &error_out,
+              const ProgressCallback &progress = nullptr);
+
+  // Send one SwitchBot plaintext command body (the bytes after the leading
+  // 0x57 command marker) to the physical lock and return the decrypted notify
+  // payload from the lock. The caller provides the key/slot for this session.
+  bool send_plaintext(const Config &config, const uint8_t *plaintext,
+                      size_t plaintext_len, std::vector<uint8_t> &response_plaintext,
+                      std::string &error_out,
+                      const ProgressCallback &progress = nullptr,
+                      const ResponseCallback &response_callback = nullptr);
+
+  // Send a short provisioning sequence over one encrypted session. This
+  // mirrors the official keypad/lock binding flow where several 0F 20 ...
+  // writes share the same IV.
+  bool send_plaintext_sequence(const Config &config,
+                               const std::vector<std::vector<uint8_t>> &commands,
+                               std::vector<std::vector<uint8_t>> &responses,
+                               std::string &error_out,
+                               const ProgressCallback &progress = nullptr,
+                               const ResponseCallback &response_callback = nullptr);
+
+  // Provision the keypad/lock shared key with the lock's cloud credential,
+  // then verify the freshly-written shared slot on the same BLE connection.
+  bool provision_and_verify_shared_key(
+      const Config &provisioning_config,
+      const std::vector<std::vector<uint8_t>> &provision_commands,
+      std::vector<std::vector<uint8_t>> &provision_responses,
+      const Config &shared_config,
+      std::string &error_out,
+      const ProgressCallback &provision_progress = nullptr,
+      const CommandProgressCallback &provision_command_progress = nullptr,
+      const ProgressCallback &verify_progress = nullptr);
+
+ private:
+  enum class CryptoMode : uint8_t { CTR, GCM };
+
+  struct Session {
+    CryptoMode mode{CryptoMode::CTR};
+    std::array<uint8_t, 16> ctr_iv{};
+    std::array<uint8_t, 12> gcm_iv{};
+  };
+
+  bool connect_(const Config &config, NimBLEClient *&client,
+                NimBLERemoteCharacteristic *&rx,
+                NimBLERemoteCharacteristic *&tx,
+                std::string &error_out,
+                const ProgressCallback &progress);
+  bool parse_session_response_(const std::string &wire, Session &session,
+                               std::string &error_out);
+  bool send_encrypted_(const Config &config, const Session &session,
+                       NimBLERemoteCharacteristic *rx, const uint8_t *plaintext,
+                       size_t plaintext_len, std::string &error_out);
+  bool decrypt_notify_(const Config &config, const Session &session,
+                       const std::string &wire, std::vector<uint8_t> &out,
+                       std::string &error_out);
+
+  // Last advertisement address seen for cached_mac_, including its BLE
+  // address type. Lets follow-up connects skip the ~2.5 s discovery scan —
+  // the dominant cost of a relay round-trip. Invalidated when a connect
+  // through it fails (the next attempt re-scans).
+  NimBLEAddress cached_addr_{};
+  std::string   cached_mac_;
+};
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
@@ -22,11 +22,6 @@ namespace {
 
 const char *const TAG = "switchbot_keypad_bridge";
 
-// BLE service / characteristic UUIDs as exposed by a real SwitchBot Lock.
-constexpr const char *SERVICE_UUID = "cba20d00-224d-11e6-9fb8-0002a5d5c51b";
-constexpr const char *RX_CHAR_UUID = "cba20002-224d-11e6-9fb8-0002a5d5c51b";
-constexpr const char *TX_CHAR_UUID = "cba20003-224d-11e6-9fb8-0002a5d5c51b";
-
 // SwitchBot's OUI. Applied to the chip's factory MAC at boot so the bridge
 // advertises within SwitchBot's address range — the Keypad Vision filters
 // scan results on this prefix.
@@ -44,11 +39,18 @@ constexpr uint8_t RESPONSE_UNLOCK[5] = {0x98, 0x08, 0x7F, 0x7F, 0x00};
 constexpr uint8_t STATE_PAYLOAD_TAIL[13] = {0x08, 0x08, 0x41, 0x00, 0x00, 0x00, 0x00,
                                             0x80, 0xF2, 0xFB, 0x00, 0x00, 0x00};
 
+constexpr uint8_t SHARED_SLOT_ORIGINAL = 0x88;
+constexpr uint8_t SHARED_SLOT_VISION   = 0xC6;
+
 constexpr size_t AES_KEY_SIZE = 16;
 
 // Battery advert scan: one short active window per interval.
 constexpr uint32_t BATTERY_SCAN_DURATION_MS = 5000;
 constexpr uint32_t BATTERY_SCAN_RETRY_MS    = 30000;
+
+bool is_shared_slot(uint8_t slot) {
+  return slot == SHARED_SLOT_ORIGINAL || slot == SHARED_SLOT_VISION;
+}
 
 }  // namespace
 
@@ -124,7 +126,7 @@ void SwitchbotKeypadBridge::push_rx_(const std::string &frame) {
 
 void SwitchbotKeypadBridge::setup() {
   // Load — or, on first boot, generate — the 16-byte AES-128 session key.
-  // unpair() rotates it; it is never part of the YAML config.
+  // reset_pairing() rotates it; it is never part of the YAML config.
   this->shared_key_pref_ =
       global_preferences->make_preference<std::array<uint8_t, 16>>(0x534B4559UL /* 'SKEY' */);
   if (!this->shared_key_pref_.load(&this->shared_key_)) {
@@ -132,7 +134,7 @@ void SwitchbotKeypadBridge::setup() {
     ESP_LOGI(TAG, "Generated a fresh shared key");
   }
 
-  // Restore the paired keypad name (if any) and publish it to the sensor.
+  // Restore the linked keypad name (if any) and publish it to the sensor.
   this->keypad_name_pref_ = global_preferences->make_preference<char[KEYPAD_NAME_MAX]>(
       0x534B5042UL /* 'SKPB' */);
   char stored_name[KEYPAD_NAME_MAX] = {};
@@ -143,23 +145,53 @@ void SwitchbotKeypadBridge::setup() {
     if (this->keypad_text_sensor_ != nullptr) {
       this->keypad_text_sensor_->publish_state(stored_name);
     }
-    ESP_LOGI(TAG, "Paired keypad: '%s'", stored_name);
+    ESP_LOGI(TAG, "Linked keypad: '%s'", stored_name);
   } else {
     if (this->keypad_text_sensor_ != nullptr) {
-      this->keypad_text_sensor_->publish_state("Unpaired");
+      this->keypad_text_sensor_->publish_state("Unlinked");
     }
   }
   this->keypad_paired_ = have_keypad;
+  this->pairing_ui_.set_keypad_paired(have_keypad);
 
   // Restore the keypad MAC + family used by the battery advert scan. Missing
-  // for keypads paired before this field existed — the scan learns it then.
+  // for keypads linked before this field existed — the scan learns it then.
   this->keypad_info_pref_ =
       global_preferences->make_preference<KeypadInfo>(0x534B4D43UL /* 'SKMC' */);
   if (!this->keypad_info_pref_.load(&this->keypad_info_)) {
     this->keypad_info_ = KeypadInfo{};
   }
+  if (this->keypad_info_.valid != 0) {
+    this->pairing_ui_.set_keypad_family(
+        static_cast<KeypadFamily>(this->keypad_info_.family));
+  }
+  this->linked_lock_pref_ =
+      global_preferences->make_preference<LinkedLockInfo>(0x534C4F43UL /* 'SLOC' */);
+  if (!this->linked_lock_pref_.load(&this->linked_lock_info_)) {
+    this->linked_lock_info_ = LinkedLockInfo{};
+  } else {
+    bool had_private_key_material = false;
+    for (uint8_t b : this->linked_lock_info_.reserved) {
+      if (b != 0) {
+        had_private_key_material = true;
+        break;
+      }
+    }
+    if (this->linked_lock_info_.valid != 0 &&
+        (had_private_key_material || !is_shared_slot(this->linked_lock_info_.slot_id))) {
+      ESP_LOGW(TAG, "Ignoring legacy linked-lock record that was not shared-key based");
+      this->linked_lock_info_ = LinkedLockInfo{};
+      this->save_and_sync_(this->linked_lock_pref_, &this->linked_lock_info_);
+    }
+  }
+  this->lock_linked_ = this->linked_lock_info_.valid != 0;
+  this->pairing_ui_.set_lock_linked(this->lock_linked_);
+  this->publish_linked_lock_();
   this->battery_scan_callbacks_ = new BatteryScanCallbacks(this);
   this->next_battery_scan_at_ = millis() + BATTERY_SCAN_RETRY_MS;
+  if (!this->lock_linked_) {
+    this->clear_lock_battery_();
+  }
 
   if (!this->prepare_keys_() || !this->prepare_ble_()) {
     this->mark_failed();
@@ -172,28 +204,83 @@ void SwitchbotKeypadBridge::setup() {
   this->pairing_ui_.set_on_paired_callback(
       [this](const std::string &name, const std::string &mac,
              KeypadFamily family) {
-        // Runs on the HTTP-server task — keep it minimal: stash the fields and
-        // raise a flag. loop() (the main task) publishes the text sensor,
-        // writes NVS and stops the server.
+        // Runs from PairingUi::poll_jobs() in loop(); keep the apply path
+        // centralized below so publishing and NVS writes stay in one place.
         this->pending_keypad_name_ = name;
         this->pending_keypad_mac_ = mac;
         this->pending_keypad_family_ = family;
         this->pending_pair_apply_.store(true, std::memory_order_release);
       });
-  // Pairing mode: with no keypad paired yet, open the wizard right away
-  // so the very first pairing needs no button press.
+  this->pairing_ui_.set_on_lock_linked_callback(
+      [this](const std::string &name, const std::string &mac,
+             PhysicalLockModel model, uint8_t slot_id) {
+        this->pending_lock_name_ = name;
+        this->pending_lock_mac_ = mac;
+        this->pending_lock_model_ = model;
+        this->pending_lock_slot_id_ = slot_id;
+        this->pending_lock_apply_.store(true, std::memory_order_release);
+      });
+  // Setup mode: with no keypad linked yet, open the wizard right away
+  // so the very first link needs no button press.
   if (!have_keypad) {
     if (this->pairing_ui_.start()) {
-      ESP_LOGI(TAG, "No keypad paired — starting pairing mode");
+      ESP_LOGI(TAG, "No keypad linked — starting setup mode");
     } else {
-      ESP_LOGW(TAG, "Pairing UI failed to start; check port 80 is free");
+      ESP_LOGW(TAG, "Setup UI failed to start; check port 80 is free");
     }
   }
 }
 
 void SwitchbotKeypadBridge::loop() {
-  // Apply a pairing that completed on the HTTP-server task. The text-sensor
-  // publish and the NVS write run here, on the main task.
+  // Observe finished wizard jobs from the main loop — this queues the pending
+  // applies below even when the browser stopped polling mid-job.
+  if (this->pairing_ui_.is_running()) {
+    this->pairing_ui_.poll_jobs();
+  }
+
+  this->apply_pending_pairing_();
+  this->apply_pending_lock_link_();
+  this->apply_pending_lock_relay_();
+
+  // Idle-close the wizard only once a keypad is linked: with nothing linked
+  // the wizard is the device's whole purpose ("setup mode") and must stay
+  // reachable — closing it would strand the first-boot flow behind the Reset
+  // button, which needlessly rotates the shared key.
+  if (this->keypad_paired_ && this->pairing_ui_.stop_if_idle(millis())) {
+    ESP_LOGI(TAG, "Setup UI stopped after 5 minutes of inactivity");
+  }
+
+  // Drain the RX queue. Swapping the vector out keeps the critical section
+  // free of allocation and copying, so the NimBLE task never waits on it.
+  std::vector<QueuedEvent> pending;
+  {
+    std::lock_guard<std::mutex> lk(this->rx_mutex_);
+    pending.swap(this->rx_queue_);
+  }
+
+  for (const auto &ev : pending) {
+    if (ev.type == QueuedEvent::CONNECT) {
+      ESP_LOGI(TAG, "Keypad connected");
+      this->session_.reset_transport();
+    } else if (ev.type == QueuedEvent::DISCONNECT) {
+      ESP_LOGI(TAG, "Keypad disconnected, restarting advertising");
+      this->session_.reset_transport();
+      NimBLEDevice::startAdvertising();
+    } else if (ev.type == QueuedEvent::RX) {
+      this->on_rx_frame_(ev.frame);
+    }
+  }
+
+  if (this->keypad_battery_level_sensor_ != nullptr ||
+      this->lock_battery_level_sensor_ != nullptr) {
+    this->apply_pending_keypad_battery_();
+    this->apply_pending_lock_battery_();
+    this->maybe_finish_battery_scan_();
+    this->maybe_start_battery_scan_();
+  }
+}
+
+void SwitchbotKeypadBridge::apply_pending_pairing_() {
   if (this->pending_pair_apply_.exchange(false, std::memory_order_acquire)) {
     const std::string &name = this->pending_keypad_name_;
 
@@ -209,120 +296,137 @@ void SwitchbotKeypadBridge::loop() {
       info.valid = 1;
     }
     this->keypad_info_ = info;
-    this->keypad_info_pref_.save(&this->keypad_info_);
-    global_preferences->sync();
+    this->save_and_sync_(this->keypad_info_pref_, &this->keypad_info_);
 
     this->keypad_paired_ = true;
-    this->last_battery_ = -1;
+    this->pairing_ui_.set_keypad_paired(true);
+    this->pairing_ui_.set_keypad_family(this->pending_keypad_family_);
+    this->last_keypad_battery_ = -1;
     // Pick the new keypad's battery up shortly, not a full interval away.
     this->next_battery_scan_at_ = millis() + 10000;
 
-    if (this->keypad_text_sensor_ != nullptr) {
-      this->keypad_text_sensor_->publish_state(name);
-    }
-    ESP_LOGI(TAG, "Paired keypad: '%s' (nvs save %s)", name.c_str(),
+    this->publish_text_or_unlinked_(this->keypad_text_sensor_, name.c_str());
+    ESP_LOGI(TAG, "Linked keypad: '%s' (nvs save %s)", name.c_str(),
              saved ? "ok" : "FAILED");
 
-    // Pairing done — close the wizard server. Defer ~2 s so the wizard's
-    // final status poll still gets its reply. set_timeout() is safe here:
-    // loop() runs on the main task.
-    this->set_timeout(2000, [this]() {
-      this->pairing_ui_.stop();
-      ESP_LOGI(TAG, "Pairing UI stopped");
-    });
-  }
-
-  // Drain the RX queue. Swapping the vector out keeps the critical section
-  // free of allocation and copying, so the NimBLE task never waits on it.
-  std::vector<QueuedEvent> pending;
-  {
-    std::lock_guard<std::mutex> lk(this->rx_mutex_);
-    pending.swap(this->rx_queue_);
-  }
-
-  for (const auto &ev : pending) {
-    if (ev.type == QueuedEvent::CONNECT) {
-      ESP_LOGI(TAG, "Keypad connected");
-      this->session_.reset();
-    } else if (ev.type == QueuedEvent::DISCONNECT) {
-      ESP_LOGI(TAG, "Keypad disconnected, restarting advertising");
-      this->session_.reset();
-      NimBLEDevice::startAdvertising();
-    } else if (ev.type == QueuedEvent::RX) {
-      this->on_rx_frame_(ev.frame);
-    }
-  }
-
-  if (this->battery_level_sensor_ != nullptr) {
-    this->apply_pending_battery_();
-    this->maybe_start_battery_scan_();
+    ESP_LOGI(TAG, "Setup UI remains open for lock linking until it is idle");
   }
 }
 
-void SwitchbotKeypadBridge::unpair() {
-  ESP_LOGI(TAG, "Unpairing — rotating the shared key and re-opening the pairing wizard");
+void SwitchbotKeypadBridge::apply_pending_lock_link_() {
+  if (this->pending_lock_apply_.exchange(false, std::memory_order_acquire)) {
+    LinkedLockInfo info{};
+    if (parse_mac_pretty(this->pending_lock_mac_, info.mac)) {
+      info.valid = 1;
+      info.model = static_cast<uint8_t>(this->pending_lock_model_);
+      info.slot_id = this->pending_lock_slot_id_;
+      this->pending_lock_name_.copy(info.name, sizeof(info.name) - 1);
+    }
+    this->linked_lock_info_ = info;
+    this->lock_linked_ = info.valid != 0;
+    this->pairing_ui_.set_lock_linked(this->lock_linked_);
+    this->save_and_sync_(this->linked_lock_pref_, &this->linked_lock_info_);
+    this->publish_linked_lock_();
+    this->clear_lock_battery_();
+    this->next_battery_scan_at_ = millis() + 5000;
+    if (this->lock_linked_) {
+      ESP_LOGI(TAG, "Linked physical lock: '%s' (%s, shared_slot=0x%02X)",
+               this->linked_lock_info_.name,
+               physical_lock_model_str(static_cast<PhysicalLockModel>(this->linked_lock_info_.model)),
+               this->linked_lock_info_.slot_id);
+    } else {
+      ESP_LOGW(TAG, "Ignoring linked lock apply with invalid MAC");
+    }
+  }
+}
+
+void SwitchbotKeypadBridge::apply_pending_lock_relay_() {
+  if (this->pending_relay_apply_.exchange(false, std::memory_order_acquire)) {
+    if (!this->relay_ok_) {
+      ESP_LOGW(TAG, "Physical lock relay finished without a lock reply");
+      return;
+    }
+    switch (this->relay_command_.type) {
+      case CommandType::LOCK:
+        ESP_LOGI(TAG, "Physical lock relay confirmed Lock");
+        return;
+      case CommandType::UNLOCK:
+        ESP_LOGI(TAG, "Physical lock relay confirmed Unlock: method=%s index=%d",
+                 unlock_method_name(this->relay_command_.method),
+                 this->relay_command_.credential_index);
+        return;
+      default:
+        ESP_LOGD(TAG, "Physical lock replied to forwarded command");
+        return;
+    }
+  }
+}
+
+void SwitchbotKeypadBridge::reset_pairing() {
+  ESP_LOGI(TAG, "Resetting links — rotating the shared key and re-opening the setup wizard");
 
   // Rotate the key and swap it into the live crypto slot: the previously
-  // paired keypad can no longer command the bridge, with no reboot needed.
+  // linked keypad can no longer command the bridge, with no reboot needed.
   this->create_shared_key_();
   if (!this->import_aes_key_()) {
-    ESP_LOGE(TAG, "Key rotation failed — unpair aborted");
+    ESP_LOGE(TAG, "Key rotation failed — reset aborted");
     return;
   }
 
   // Stop an in-flight battery scan window: the wizard's own blocking scans
   // share the NimBLE scan singleton and must not race it.
-  if (this->battery_scan_active_.exchange(false)) {
-    NimBLEScan *scan = NimBLEDevice::getScan();
-    if (scan->isScanning()) {
-      scan->stop();
-    }
-    scan->clearResults();
-  }
+  this->stop_battery_scan_();
 
-  // Forget the paired keypad name and its battery-scan identity.
+  // Forget the linked keypad name and its battery-scan identity.
   char empty[KEYPAD_NAME_MAX] = {};
   this->keypad_name_pref_.save(&empty);
   this->keypad_info_ = KeypadInfo{};
   this->keypad_info_pref_.save(&this->keypad_info_);
+  this->linked_lock_info_ = LinkedLockInfo{};
+  this->linked_lock_pref_.save(&this->linked_lock_info_);
   global_preferences->sync();
-  if (this->keypad_text_sensor_ != nullptr) {
-    this->keypad_text_sensor_->publish_state("Unpaired");
-  }
+  this->publish_text_or_unlinked_(this->keypad_text_sensor_, nullptr);
+  this->lock_linked_ = false;
+  this->pairing_ui_.set_lock_linked(false);
+  this->publish_linked_lock_();
+  this->clear_lock_battery_();
   this->keypad_paired_ = false;
-  this->last_battery_ = -1;
-  if (this->battery_level_sensor_ != nullptr) {
-    this->battery_level_sensor_->publish_state(NAN);
-  }
+  this->pairing_ui_.set_keypad_paired(false);
+  this->pairing_ui_.set_keypad_family(KeypadFamily::ORIGINAL);
+  this->reset_battery_sensor_(this->keypad_battery_level_sensor_,
+                              this->last_keypad_battery_);
 
   // Invalidate any in-flight BLE session — it is keyed to the old secret —
   // and forget the learned token slot along with it.
   this->session_.reset();
   this->session_.forget_slot();
 
-  // Re-enter pairing mode straight away with the rotated key.
+  // Re-enter setup mode straight away with the rotated key.
   this->pairing_ui_.set_shared_key(this->shared_key_);
   if (this->pairing_ui_.start()) {
-    ESP_LOGI(TAG, "Unpaired — re-entering pairing mode");
+    ESP_LOGI(TAG, "Reset complete — re-entering setup mode");
   } else {
-    ESP_LOGW(TAG, "Pairing UI failed to start; check port 80 is free");
+    ESP_LOGW(TAG, "Setup UI failed to start; check port 80 is free");
   }
 }
 
-void UnpairButton::press_action() {
+void ResetButton::press_action() {
   if (this->parent_->is_pairing_active()) {
-    ESP_LOGW(TAG, "Pairing is already active, ignoring Unpair action");
+    ESP_LOGW(TAG, "Setup wizard is already active, ignoring Reset action");
     return;
   }
-  this->parent_->unpair();
+  this->parent_->reset_pairing();
 }
 
 void SwitchbotKeypadBridge::dump_config() {
   ESP_LOGCONFIG(TAG, "SwitchBot Keypad Bridge:");
   ESP_LOGCONFIG(TAG, "  BLE address: %s", NimBLEDevice::getAddress().toString().c_str());
-  ESP_LOGCONFIG(TAG, "  Pairing UI: port 80");
-  if (this->battery_level_sensor_ != nullptr) {
-    ESP_LOGCONFIG(TAG, "  Battery scan interval: %us",
+  ESP_LOGCONFIG(TAG, "  Setup UI: port 80");
+  ESP_LOGCONFIG(TAG, "  Physical lock relay: %s",
+                this->lock_linked_ ? this->linked_lock_info_.name : "Unlinked");
+  if (this->keypad_battery_level_sensor_ != nullptr ||
+      this->lock_battery_level_sensor_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Battery refresh interval: %us",
                   static_cast<unsigned>(this->battery_scan_interval_ms_ / 1000));
   }
   if (this->is_failed()) {
@@ -338,7 +442,7 @@ void SwitchbotKeypadBridge::create_shared_key_() {
 
 bool SwitchbotKeypadBridge::import_aes_key_() {
   // Drop any previously imported handle so the slot can be re-keyed in
-  // place — unpair() rotates the key without rebooting.
+  // place — reset_pairing() rotates the key without rebooting.
   if (this->aes_key_handle_ != PSA_KEY_ID_NULL) {
     psa_destroy_key(this->aes_key_handle_);
     this->aes_key_handle_ = PSA_KEY_ID_NULL;
@@ -396,10 +500,11 @@ bool SwitchbotKeypadBridge::prepare_ble_() {
   this->server_ = NimBLEDevice::createServer();
   this->server_->setCallbacks(new ServerCallbacks(this));
 
-  NimBLEService *service = this->server_->createService(SERVICE_UUID);
-  this->tx_characteristic_ = service->createCharacteristic(TX_CHAR_UUID, NIMBLE_PROPERTY::NOTIFY);
+  NimBLEService *service = this->server_->createService(SWITCHBOT_SERVICE_UUID);
+  this->tx_characteristic_ =
+      service->createCharacteristic(SWITCHBOT_TX_CHAR_UUID, NIMBLE_PROPERTY::NOTIFY);
   NimBLECharacteristic *rx = service->createCharacteristic(
-      RX_CHAR_UUID, NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_NR);
+      SWITCHBOT_RX_CHAR_UUID, NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_NR);
   rx->setCallbacks(new RxCharCallbacks(this));
 
   NimBLEAdvertising *advertising = NimBLEDevice::getAdvertising();
@@ -429,13 +534,15 @@ void SwitchbotKeypadBridge::on_rx_frame_(const std::string &frame) {
 }
 
 void SwitchbotKeypadBridge::handle_command_(const FrameHeader &header, const DecodedCommand &command) {
+  // Publish decoded Home Assistant events immediately: the event reports the
+  // keypad action itself, so automations must not wait for the physical
+  // lock's BLE round-trip (which runs in parallel below).
   switch (command.type) {
     case CommandType::LOCK:
       ESP_LOGI(TAG, "Lock");
       this->lock_state_ = LockState::LOCKED;
       this->publish_lock_();
-      this->send_encrypted_response_(header, RESPONSE_LOCK, sizeof(RESPONSE_LOCK));
-      return;
+      break;
 
     case CommandType::UNLOCK:
       ESP_LOGI(TAG, "Unlock: method=%s (0x%02X) index=%d",
@@ -443,21 +550,63 @@ void SwitchbotKeypadBridge::handle_command_(const FrameHeader &header, const Dec
                static_cast<uint8_t>(command.method), command.credential_index);
       this->lock_state_ = LockState::UNLOCKED;
       this->publish_unlock_(command.method, command.credential_index);
-      this->send_encrypted_response_(header, RESPONSE_UNLOCK, sizeof(RESPONSE_UNLOCK));
-      return;
+      break;
 
     case CommandType::STATE_POLL:
       ESP_LOGV(TAG, "State poll");
-      this->handle_state_poll_(header);
-      return;
+      break;
 
     case CommandType::DOORBELL:
       ESP_LOGI(TAG, "Doorbell");
       this->publish_doorbell_();
-      // No lock-state change; the keypad only needs the transport ACK.
+      break;
+
+    case CommandType::UNKNOWN:
+    default:
+      break;
+  }
+
+  // With a physical lock linked, answer the keypad exactly like standalone
+  // mode and mirror side-effecting payloads onto the lock in the background.
+  // The keypad must never wait for, or receive, the physical lock's reply.
+  if (this->lock_linked_) {
+    this->send_local_response_(header, command);
+    switch (command.type) {
+      case CommandType::LOCK:
+      case CommandType::UNLOCK:
+      case CommandType::UNKNOWN:
+        if (!this->relay_to_lock_async_(header, command)) {
+          ESP_LOGW(TAG, "Physical lock relay unavailable after local keypad response");
+        }
+        return;
+      case CommandType::STATE_POLL:
+      case CommandType::DOORBELL:
+      default:
+        return;
+    }
+  }
+
+  // Local answer only when no physical lock is linked.
+  this->send_local_response_(header, command);
+}
+
+// Answer the keypad locally. Linked-lock mode uses the same path; the lock's
+// eventual reply is logged but never forwarded back to the keypad.
+void SwitchbotKeypadBridge::send_local_response_(const FrameHeader &header,
+                                                 const DecodedCommand &command) {
+  switch (command.type) {
+    case CommandType::LOCK:
+      this->send_encrypted_response_(header, RESPONSE_LOCK, sizeof(RESPONSE_LOCK));
+      return;
+    case CommandType::UNLOCK:
+      this->send_encrypted_response_(header, RESPONSE_UNLOCK, sizeof(RESPONSE_UNLOCK));
+      return;
+    case CommandType::STATE_POLL:
+      this->handle_state_poll_(header);
+      return;
+    case CommandType::DOORBELL:
       this->send_ack_(header);
       return;
-
     case CommandType::UNKNOWN:
     default:
       this->send_ack_(header);
@@ -472,22 +621,118 @@ void SwitchbotKeypadBridge::handle_state_poll_(const FrameHeader &header) {
   this->send_encrypted_response_(header, state_payload, sizeof(state_payload));
 }
 
+PhysicalLockClient::Config SwitchbotKeypadBridge::physical_lock_config_(uint8_t slot_id) const {
+  PhysicalLockClient::Config cfg;
+  cfg.mac = "";
+  if (this->linked_lock_info_.valid != 0) {
+    char mac[18];
+    std::snprintf(mac, sizeof(mac), "%02X:%02X:%02X:%02X:%02X:%02X",
+                  this->linked_lock_info_.mac[0], this->linked_lock_info_.mac[1],
+                  this->linked_lock_info_.mac[2], this->linked_lock_info_.mac[3],
+                  this->linked_lock_info_.mac[4], this->linked_lock_info_.mac[5]);
+    cfg.mac = mac;
+    cfg.model = static_cast<PhysicalLockModel>(this->linked_lock_info_.model);
+    cfg.key_id = slot_id;
+    cfg.key = this->shared_key_;
+  }
+  return cfg;
+}
+
+bool SwitchbotKeypadBridge::relay_to_lock_async_(const FrameHeader &header,
+                                                 const DecodedCommand &command) {
+  if (this->session_.plaintext_size() == 0) {
+    ESP_LOGW(TAG, "Cannot relay command: no decrypted keypad plaintext");
+    return false;
+  }
+  if (this->lock_relay_busy_.exchange(true)) {
+    ESP_LOGW(TAG, "Lock relay still in flight — answering this command locally");
+    return false;
+  }
+  // The relay opens a central connection; make sure the battery advert scan
+  // isn't holding the radio.
+  this->stop_battery_scan_();
+
+  // Snapshot everything the task needs now: the session buffer is reused by
+  // the next keypad frame, and the config must not be read off-thread.
+  struct RelayCtx {
+    SwitchbotKeypadBridge *self;
+    PhysicalLockClient::Config cfg;
+    std::vector<uint8_t> plaintext;
+    DecodedCommand command;
+  };
+  auto *ctx = new RelayCtx{
+      this, this->physical_lock_config_(header.key_id),
+      {this->session_.plaintext(),
+       this->session_.plaintext() + this->session_.plaintext_size()},
+      command};
+
+  BaseType_t rc = xTaskCreatePinnedToCore(
+      [](void *raw) {
+        auto *c = static_cast<RelayCtx *>(raw);
+        std::vector<uint8_t> response;
+        std::string error;
+        bool result_posted = false;
+        auto post_relay_result = [c, &result_posted](bool ok) {
+          c->self->relay_command_  = c->command;
+          c->self->relay_ok_       = ok;
+          c->self->pending_relay_apply_.store(true, std::memory_order_release);
+          result_posted = true;
+        };
+        const bool ok = c->self->physical_lock_client_.send_plaintext(
+            c->cfg, c->plaintext.data(), c->plaintext.size(), response, error,
+            nullptr,
+            [&post_relay_result](const std::vector<uint8_t> &reply) {
+              // The keypad already got its local response. This callback only
+              // lets loop() log that the physical lock replied.
+              (void) reply;
+              post_relay_result(true);
+            });
+        if (!ok) {
+          ESP_LOGW(TAG, "Lock relay command failed: %s", error.c_str());
+        }
+        // If the lock never produced a response, hand the final outcome to
+        // loop() after send_plaintext() returns. Successful replies are noted
+        // immediately by the callback above.
+        if (!result_posted) {
+          post_relay_result(ok);
+        }
+        c->self->lock_relay_busy_.store(false);
+        delete c;
+        vTaskDelete(nullptr);
+      },
+      "lock-relay", 8192, ctx, tskIDLE_PRIORITY + 2, nullptr,
+      // Same core as the BT task, matching the pairer/linker jobs.
+      0);
+  if (rc != pdPASS) {
+    delete ctx;
+    this->lock_relay_busy_.store(false);
+    ESP_LOGW(TAG, "Could not start the lock relay task");
+    return false;
+  }
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // Transport
 // ---------------------------------------------------------------------------
 
 void SwitchbotKeypadBridge::send_ack_(const FrameHeader &header) {
   const uint8_t ack[LockSession::HEADER_LEN] = {0x01, header.key_id, header.seq_a, header.seq_b};
+  ESP_LOGV(TAG, "TX keypad ack %s",
+           format_hex_pretty(ack, sizeof(ack)).c_str());
   this->notify_(ack, sizeof(ack));
 }
 
 void SwitchbotKeypadBridge::send_encrypted_response_(const FrameHeader &header,
                                                     const uint8_t *plaintext, size_t length) {
+  ESP_LOGV(TAG, "TX keypad plaintext %s",
+           format_hex_pretty(plaintext, length).c_str());
   uint8_t packet[LockSession::MAX_PACKET];
   const size_t n = this->session_.encrypt_response(header, plaintext, length, packet);
   if (n == 0) {
     return;  // error already logged
   }
+  ESP_LOGV(TAG, "TX keypad %s", format_hex_pretty(packet, n).c_str());
   this->notify_(packet, n);
 }
 
@@ -522,18 +767,64 @@ void SwitchbotKeypadBridge::publish_doorbell_() {
   this->on_doorbell_callbacks_.call();
 }
 
+void SwitchbotKeypadBridge::publish_linked_lock_() {
+  if (this->lock_linked_ && this->linked_lock_info_.valid != 0 &&
+      this->linked_lock_info_.name[0] != '\0') {
+    this->publish_text_or_unlinked_(this->linked_lock_text_sensor_,
+                                    this->linked_lock_info_.name);
+  } else {
+    this->publish_text_or_unlinked_(this->linked_lock_text_sensor_, nullptr);
+  }
+}
+
+void SwitchbotKeypadBridge::save_and_sync_(ESPPreferenceObject &pref,
+                                           const KeypadInfo *value) {
+  pref.save(value);
+  global_preferences->sync();
+}
+
+void SwitchbotKeypadBridge::save_and_sync_(ESPPreferenceObject &pref,
+                                           const LinkedLockInfo *value) {
+  pref.save(value);
+  global_preferences->sync();
+}
+
+void SwitchbotKeypadBridge::publish_text_or_unlinked_(
+    text_sensor::TextSensor *sensor, const char *value) {
+  if (sensor == nullptr) {
+    return;
+  }
+  sensor->publish_state((value != nullptr && value[0] != '\0') ? value : "Unlinked");
+}
+
+void SwitchbotKeypadBridge::publish_battery_if_changed_(
+    sensor::Sensor *sensor, int value, int &last, const char *label) {
+  ESP_LOGD(TAG, "%s battery: %d%%", label, value);
+  if (sensor != nullptr && value != last) {
+    last = value;
+    sensor->publish_state(static_cast<float>(value));
+  }
+}
+
+void SwitchbotKeypadBridge::reset_battery_sensor_(sensor::Sensor *sensor,
+                                                  int &last) {
+  last = -1;
+  if (sensor != nullptr) {
+    sensor->publish_state(NAN);
+  }
+}
+
 // ---------------------------------------------------------------------------
-// Keypad battery (advertisement scan)
+// Battery refresh (advertisement scan)
 // ---------------------------------------------------------------------------
 
 void SwitchbotKeypadBridge::maybe_start_battery_scan_() {
   const uint32_t now = millis();
 
-  if (this->battery_scan_active_) {
+  if (this->battery_scan_active_.load(std::memory_order_acquire)) {
     // NimBLE drops isScanning() when the window elapses or stop() ran.
     if (!NimBLEDevice::getScan()->isScanning()) {
-      this->battery_scan_active_ = false;
-      NimBLEDevice::getScan()->clearResults();
+      this->stop_battery_scan_();
       this->next_battery_scan_at_ = now + this->battery_scan_interval_ms_;
     }
     return;
@@ -543,25 +834,54 @@ void SwitchbotKeypadBridge::maybe_start_battery_scan_() {
     return;
   }
 
+  const bool wants_keypad =
+      this->keypad_battery_level_sensor_ != nullptr && this->keypad_paired_;
+  const bool wants_lock = this->lock_battery_level_sensor_ != nullptr &&
+                          this->lock_linked_ &&
+                          this->linked_lock_info_.valid != 0;
+  if (!wants_keypad && !wants_lock) {
+    this->next_battery_scan_at_ = now + BATTERY_SCAN_RETRY_MS;
+    return;
+  }
+
   // The scan singleton is shared with the pairing flows (which run blocking
   // scans), and the keypad does not advertise while it holds a connection to
   // us — defer rather than fight either.
-  if (!this->keypad_paired_ || this->pairing_ui_.is_running() ||
-      (this->server_ != nullptr && this->server_->getConnectedCount() > 0) ||
+  if (this->background_ble_busy_() ||
       NimBLEDevice::getScan()->isScanning()) {
     this->next_battery_scan_at_ = now + BATTERY_SCAN_RETRY_MS;
     return;
   }
 
+  this->battery_scan_wants_keypad_ = wants_keypad;
+  this->battery_scan_wants_lock_ = wants_lock;
+  this->keypad_battery_scan_found_ = false;
+  this->lock_battery_scan_found_ = false;
+  this->battery_scan_keypad_known_ = this->keypad_info_.valid != 0;
+  if (this->battery_scan_keypad_known_) {
+    std::memcpy(this->battery_scan_keypad_mac_, this->keypad_info_.mac,
+                sizeof(this->battery_scan_keypad_mac_));
+    this->battery_scan_keypad_family_ = this->keypad_info_.family;
+  }
+  if (wants_lock) {
+    std::memcpy(this->battery_scan_lock_mac_, this->linked_lock_info_.mac,
+                sizeof(this->battery_scan_lock_mac_));
+    this->battery_scan_lock_model_ =
+        static_cast<PhysicalLockModel>(this->linked_lock_info_.model);
+  } else {
+    this->battery_scan_lock_model_ = PhysicalLockModel::UNKNOWN;
+  }
+
   NimBLEScan *scan = NimBLEDevice::getScan();
   scan->setScanCallbacks(this->battery_scan_callbacks_, false);
   configure_switchbot_scan(scan);
+  this->battery_scan_active_.store(true, std::memory_order_release);
   if (scan->start(BATTERY_SCAN_DURATION_MS, false, true)) {
-    this->battery_scan_active_ = true;
     ESP_LOGD(TAG, "Battery scan window opened (%u ms)",
              static_cast<unsigned>(BATTERY_SCAN_DURATION_MS));
   } else {
     ESP_LOGW(TAG, "Battery scan failed to start");
+    this->stop_battery_scan_();
     this->next_battery_scan_at_ = now + BATTERY_SCAN_RETRY_MS;
   }
 }
@@ -569,76 +889,147 @@ void SwitchbotKeypadBridge::maybe_start_battery_scan_() {
 void SwitchbotKeypadBridge::handle_battery_advert_(const NimBLEAdvertisedDevice *adv) {
   // The callbacks stay registered on the shared scan singleton, so pairing
   // scans fire them too — only act inside our own scan window.
-  if (!this->battery_scan_active_.load(std::memory_order_relaxed)) {
+  if (!this->battery_scan_active_.load(std::memory_order_acquire)) {
     return;
   }
 
   const std::array<uint8_t, 6> mac = addr_bytes(adv->getAddress());
   const std::vector<uint8_t> sd = switchbot_service_data(adv);
 
-  KeypadFamily family;
-  if (this->keypad_info_.valid != 0) {
-    if (std::memcmp(mac.data(), this->keypad_info_.mac, mac.size()) != 0) return;
-    family = static_cast<KeypadFamily>(this->keypad_info_.family);
-  } else {
-    // Keypad paired before the MAC was persisted: adopt the first advert
-    // matching a known keypad signature (loop() persists it).
-    const KeypadIdent ident = identify_keypad(sd.data(), sd.size());
-    if (!ident.is_keypad) return;
-    family = ident.family;
-  }
-
   std::string mfr;
   if (adv->haveManufacturerData()) {
     mfr = adv->getManufacturerData();
   }
-  const int battery = parse_keypad_battery(
-      family, sd.data(), sd.size(),
-      reinterpret_cast<const uint8_t *>(mfr.data()), mfr.size());
-  if (battery < 0) {
-    return;
+
+  if (this->battery_scan_wants_keypad_ && !this->keypad_battery_scan_found_) {
+    bool keypad_match = false;
+    KeypadFamily family = KeypadFamily::ORIGINAL;
+    if (this->battery_scan_keypad_known_) {
+      keypad_match =
+          std::memcmp(mac.data(), this->battery_scan_keypad_mac_, mac.size()) == 0;
+      family = static_cast<KeypadFamily>(this->battery_scan_keypad_family_);
+    } else {
+      // Keypad linked before the MAC was persisted: adopt the first advert
+      // matching a known keypad signature (loop() persists it).
+      const KeypadIdent ident = identify_keypad(sd.data(), sd.size());
+      keypad_match = ident.is_keypad;
+      family = ident.family;
+    }
+
+    if (keypad_match) {
+      const int battery = parse_keypad_battery(
+          family, sd.data(), sd.size(),
+          reinterpret_cast<const uint8_t *>(mfr.data()), mfr.size());
+      if (battery >= 0) {
+        std::lock_guard<std::mutex> lk(this->rx_mutex_);
+        this->keypad_battery_advert_value_ = battery;
+        std::memcpy(this->keypad_battery_advert_mac_, mac.data(), mac.size());
+        this->keypad_battery_advert_family_ = static_cast<uint8_t>(family);
+        this->keypad_battery_advert_pending_ = true;
+      }
+    }
   }
 
-  std::lock_guard<std::mutex> lk(this->rx_mutex_);
-  this->battery_advert_value_ = battery;
-  std::memcpy(this->battery_advert_mac_, mac.data(), mac.size());
-  this->battery_advert_family_ = static_cast<uint8_t>(family);
-  this->battery_advert_pending_ = true;
+  if (this->battery_scan_wants_lock_ && !this->lock_battery_scan_found_ &&
+      std::memcmp(mac.data(), this->battery_scan_lock_mac_, mac.size()) == 0) {
+    const std::vector<uint8_t> mfr_payload = switchbot_manufacturer_payload(adv);
+    const int battery = parse_lock_battery(
+        this->battery_scan_lock_model_, sd.data(), sd.size(),
+        mfr_payload.data(), mfr_payload.size());
+    if (battery >= 0) {
+      std::lock_guard<std::mutex> lk(this->rx_mutex_);
+      this->lock_battery_advert_value_ = battery;
+      this->lock_battery_advert_pending_ = true;
+    }
+  }
 }
 
-void SwitchbotKeypadBridge::apply_pending_battery_() {
+// ---------------------------------------------------------------------------
+// Battery advertisement scan
+// ---------------------------------------------------------------------------
+
+void SwitchbotKeypadBridge::apply_pending_keypad_battery_() {
   int value;
   uint8_t mac[6];
   uint8_t family;
   {
     std::lock_guard<std::mutex> lk(this->rx_mutex_);
-    if (!this->battery_advert_pending_) return;
-    this->battery_advert_pending_ = false;
-    value = this->battery_advert_value_;
-    std::memcpy(mac, this->battery_advert_mac_, sizeof(mac));
-    family = this->battery_advert_family_;
+    if (!this->keypad_battery_advert_pending_) return;
+    this->keypad_battery_advert_pending_ = false;
+    value = this->keypad_battery_advert_value_;
+    std::memcpy(mac, this->keypad_battery_advert_mac_, sizeof(mac));
+    family = this->keypad_battery_advert_family_;
   }
 
   if (this->keypad_info_.valid == 0) {
     std::memcpy(this->keypad_info_.mac, mac, sizeof(this->keypad_info_.mac));
     this->keypad_info_.family = family;
     this->keypad_info_.valid = 1;
-    this->keypad_info_pref_.save(&this->keypad_info_);
-    global_preferences->sync();
+    this->save_and_sync_(this->keypad_info_pref_, &this->keypad_info_);
     ESP_LOGI(TAG, "Learned keypad MAC %02X:%02X:%02X:%02X:%02X:%02X from advertisement",
              mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
   }
 
-  // Got what we came for — close the scan window early.
-  if (this->battery_scan_active_ && NimBLEDevice::getScan()->isScanning()) {
-    NimBLEDevice::getScan()->stop();
+  // Mark this target as satisfied; the window closes once every expected
+  // target has reported.
+  this->keypad_battery_scan_found_ = true;
+  this->publish_battery_if_changed_(this->keypad_battery_level_sensor_, value,
+                                    this->last_keypad_battery_, "Keypad");
+}
+
+void SwitchbotKeypadBridge::apply_pending_lock_battery_() {
+  int value;
+  {
+    std::lock_guard<std::mutex> lk(this->rx_mutex_);
+    if (!this->lock_battery_advert_pending_) return;
+    this->lock_battery_advert_pending_ = false;
+    value = this->lock_battery_advert_value_;
   }
 
-  ESP_LOGD(TAG, "Keypad battery: %d%%", value);
-  if (this->battery_level_sensor_ != nullptr && value != this->last_battery_) {
-    this->last_battery_ = value;
-    this->battery_level_sensor_->publish_state(static_cast<float>(value));
+  this->lock_battery_scan_found_ = true;
+  this->publish_battery_if_changed_(this->lock_battery_level_sensor_, value,
+                                    this->last_lock_battery_, "Lock");
+}
+
+void SwitchbotKeypadBridge::maybe_finish_battery_scan_() {
+  if (!this->battery_scan_active_.load(std::memory_order_acquire)) {
+    return;
   }
+  if (this->battery_scan_wants_keypad_ && !this->keypad_battery_scan_found_) {
+    return;
+  }
+  if (this->battery_scan_wants_lock_ && !this->lock_battery_scan_found_) {
+    return;
+  }
+  this->stop_battery_scan_();
+  this->next_battery_scan_at_ = millis() + this->battery_scan_interval_ms_;
+}
+
+void SwitchbotKeypadBridge::stop_battery_scan_() {
+  if (this->battery_scan_active_.exchange(false, std::memory_order_acq_rel)) {
+    NimBLEScan *scan = NimBLEDevice::getScan();
+    if (scan->isScanning()) {
+      scan->stop();
+    }
+    scan->clearResults();
+  }
+  this->battery_scan_wants_keypad_ = false;
+  this->battery_scan_wants_lock_ = false;
+  this->keypad_battery_scan_found_ = false;
+  this->lock_battery_scan_found_ = false;
+  this->battery_scan_keypad_known_ = false;
+  this->battery_scan_lock_model_ = PhysicalLockModel::UNKNOWN;
+}
+
+bool SwitchbotKeypadBridge::background_ble_busy_() const {
+  return this->pairing_ui_.is_running() ||
+         this->lock_relay_busy_.load(std::memory_order_relaxed) ||
+         (this->server_ != nullptr && this->server_->getConnectedCount() > 0);
+}
+
+void SwitchbotKeypadBridge::clear_lock_battery_() {
+  this->reset_battery_sensor_(this->lock_battery_level_sensor_,
+                              this->last_lock_battery_);
 }
 
 }  // namespace switchbot_keypad_bridge

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
@@ -20,10 +20,13 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 
+#include "keypad_advert.h"
+#include "lock_advert.h"
 #include "lock_protocol.h"
 #include "lock_session.h"
 #include "nimble_compat.h"
 #include "pairing_ui.h"
+#include "physical_lock.h"
 
 namespace esphome {
 namespace switchbot_keypad_bridge {
@@ -37,7 +40,7 @@ constexpr size_t KEYPAD_NAME_MAX = 48;
 // and the ESPHome-facing business logic on top of them.
 
 // ── Concurrency model ───────────────────────────────────────────────────────
-// Four execution contexts touch this component. The rule of thumb: only the
+// Five execution contexts touch this component. The rule of thumb: only the
 // main task acts; every other context hands data over and returns.
 //
 //   1. ESPHome main task — setup()/loop() and everything they call. The only
@@ -45,18 +48,21 @@ constexpr size_t KEYPAD_NAME_MAX = 48;
 //      battery-scan state.
 //   2. NimBLE host task — server/characteristic callbacks and the battery
 //      scan callback. They only enqueue: connect/disconnect/RX frames into
-//      rx_queue_, battery adverts into the battery_advert_* fields — both
+//      rx_queue_, keypad battery adverts into the keypad_battery_advert_* fields — both
 //      under rx_mutex_, both drained by loop().
-//   3. HTTP-server task (pairing wizard) — signals a finished pairing through
-//      the pending_keypad_* fields plus the pending_pair_apply_ flag. The
-//      fields are written first, then the flag is stored with release
-//      semantics; loop() exchanges the flag with acquire before reading them.
-//      When adding a pending field, write it BEFORE the flag store.
-//   4. Pairing FreeRTOS task ("kp-pair") — owned by KeypadPairer, which
-//      exposes progress as Status snapshots copied under its own mutex.
+//   3. HTTP-server task (setup wizard) — handles requests, starts keypad
+//      pairing / lock-link jobs and reports Status snapshots. It does not
+//      publish entities or write NVS.
+//   4. Pairing/linking FreeRTOS tasks ("kp-pair", "lock-link") — owned by
+//      their job classes, which expose progress snapshots under their own
+//      mutexes. PairingUi::poll_jobs() observes completion from loop().
+//   5. Relay FreeRTOS task ("lock-relay") — forwards one keypad payload to
+//      the physical lock and posts only the relay outcome through pending_relay_*.
 class SwitchbotKeypadBridge : public Component {
   SUB_TEXT_SENSOR(keypad)
-  SUB_SENSOR(battery_level)
+  SUB_TEXT_SENSOR(linked_lock)
+  SUB_SENSOR(keypad_battery_level)
+  SUB_SENSOR(lock_battery_level)
 
  public:
   void setup() override;
@@ -72,9 +78,9 @@ class SwitchbotKeypadBridge : public Component {
 
   bool is_pairing_active() const { return this->pairing_ui_.is_running(); }
 
-  // Forgets the paired keypad, rotates the shared key in place and
-  // re-opens the pairing wizard — no reboot. Invoked by UnpairButton.
-  void unpair();
+  // Forgets the linked keypad and lock, rotates the shared key in place and
+  // re-opens the setup wizard — no reboot. Invoked by ResetButton.
+  void reset_pairing();
 
   void add_on_lock_callback(std::function<void()> &&callback) {
     this->on_lock_callbacks_.add(std::move(callback));
@@ -99,9 +105,9 @@ class SwitchbotKeypadBridge : public Component {
     UNLOCKED = 0x91,
   };
 
-  // Identity of the paired keypad, persisted to NVS at pairing time so the
+  // Identity of the linked keypad, persisted to NVS at pairing time so the
   // battery scan can match its advertisement after a reboot. `valid == 0`
-  // for keypads paired before this field existed — the scan then learns the
+  // for keypads linked before this field existed — the scan then learns the
   // MAC from the first recognised keypad advert and persists it.
   struct KeypadInfo {
     uint8_t mac[6]{};   // big-endian, as printed
@@ -109,13 +115,26 @@ class SwitchbotKeypadBridge : public Component {
     uint8_t valid{0};
   };
 
+  static constexpr size_t LOCK_NAME_MAX = 48;
+  struct LinkedLockInfo {
+    uint8_t mac[6]{};
+    // Kept for NVS layout compatibility with early relay builds that stored
+    // secret lock bytes here. It is zeroed on load/save and never used for
+    // relay.
+    uint8_t reserved[16]{};
+    uint8_t slot_id{0};
+    uint8_t model{0};  // PhysicalLockModel
+    uint8_t valid{0};
+    char name[LOCK_NAME_MAX]{};
+  };
+
   // ----- Configuration / setup -----------------------------------------------
 
   // Generates a fresh AES-128 session key into shared_key_ and persists it
-  // to NVS — the one place keys are created (first boot and unpair()).
+  // to NVS — the one place keys are created (first boot and reset_pairing()).
   void create_shared_key_();
   // (Re-)imports shared_key_ into the PSA crypto slot, replacing any handle
-  // imported earlier. Lets unpair() re-key the live session without a reboot.
+  // imported earlier. Lets reset_pairing() re-key the live session without a reboot.
   bool import_aes_key_();
 
   bool prepare_keys_();
@@ -129,6 +148,14 @@ class SwitchbotKeypadBridge : public Component {
 
   void handle_command_(const FrameHeader &header, const DecodedCommand &command);
   void handle_state_poll_(const FrameHeader &header);
+  // Builds the keypad-family reply for a command. Linked-lock mode still
+  // answers the keypad locally; the physical relay runs independently.
+  void send_local_response_(const FrameHeader &header, const DecodedCommand &command);
+  // Mirrors the just-decrypted keypad payload onto the physical lock from a
+  // one-shot background task. The keypad is never answered from this path;
+  // relay completion is logged only.
+  bool relay_to_lock_async_(const FrameHeader &header, const DecodedCommand &command);
+  PhysicalLockClient::Config physical_lock_config_(uint8_t slot_id) const;
 
   // ----- Transport helpers ---------------------------------------------------
 
@@ -141,16 +168,30 @@ class SwitchbotKeypadBridge : public Component {
   void publish_lock_();
   void publish_unlock_(UnlockMethod method, int index);
   void publish_doorbell_();
+  void publish_linked_lock_();
 
-  // ----- Keypad battery (advertisement scan) ----------------------------------
+  // ----- Battery refresh (advertisement scan) --------------------------------
 
-  // The keypad broadcasts its battery level in its BLE advertisement (the
-  // command frames it sends us never carry it). A short active scan picks
-  // the advert up while the bridge keeps advertising as the lock.
+  // Keypad and physical lock battery levels are read from BLE advertisements.
+  // A short active scan can refresh both sensors and closes early once every
+  // configured target has been seen.
   void maybe_start_battery_scan_();
-  void apply_pending_battery_();
+  void maybe_finish_battery_scan_();
+  void stop_battery_scan_();
+  void apply_pending_keypad_battery_();
+  void apply_pending_lock_battery_();
   // Runs on the NimBLE host task — parses the advert and queues the result.
   void handle_battery_advert_(const NimBLEAdvertisedDevice *adv);
+
+  // ----- Battery helpers -----------------------------------------------------
+
+  void clear_lock_battery_();
+  bool background_ble_busy_() const;
+  void save_and_sync_(ESPPreferenceObject &pref, const KeypadInfo *value);
+  void save_and_sync_(ESPPreferenceObject &pref, const LinkedLockInfo *value);
+  void publish_text_or_unlinked_(text_sensor::TextSensor *sensor, const char *value);
+  void publish_battery_if_changed_(sensor::Sensor *sensor, int value, int &last, const char *label);
+  void reset_battery_sensor_(sensor::Sensor *sensor, int &last);
 
   // ----- BLE handles ---------------------------------------------------------
 
@@ -171,19 +212,27 @@ class SwitchbotKeypadBridge : public Component {
   void push_disconnect_();
   void push_rx_(const std::string &frame);
 
-  // ----- On-device pairing wizard --------------------------------------------
+  // ----- On-device setup wizard ----------------------------------------------
 
   PairingUi pairing_ui_{};
 
-  // A finished pairing is signalled from the HTTP-server task; loop() (the
-  // main task) consumes it and publishes the keypad name + writes NVS, so
-  // neither runs on the network task. pending_keypad_name_ is written
-  // before the flag is set — the release/acquire pair makes it safe to
-  // read once the flag is observed.
+  void apply_pending_pairing_();
+  void apply_pending_lock_link_();
+  void apply_pending_lock_relay_();
+
+  // A finished pairing/link is observed by PairingUi::poll_jobs() from loop().
+  // The callback copies the completed job into these pending fields, then the
+  // apply block below publishes entities and writes NVS in one place.
   std::atomic<bool> pending_pair_apply_{false};
   std::string pending_keypad_name_;
   std::string pending_keypad_mac_;
   KeypadFamily pending_keypad_family_{KeypadFamily::ORIGINAL};
+
+  std::atomic<bool> pending_lock_apply_{false};
+  std::string pending_lock_name_;
+  std::string pending_lock_mac_;
+  PhysicalLockModel pending_lock_model_{PhysicalLockModel::UNKNOWN};
+  uint8_t pending_lock_slot_id_{0};
 
   // ----- ESPHome wiring ------------------------------------------------------
 
@@ -195,10 +244,11 @@ class SwitchbotKeypadBridge : public Component {
   // ----- User configuration --------------------------------------------------
 
   // 16-byte AES-128 session key. Generated on first boot, persisted in
-  // NVS, rotated by unpair(). Never part of the YAML config.
+  // NVS, rotated by reset_pairing(). Never part of the YAML config.
   std::array<uint8_t, 16> shared_key_{};
   ESPPreferenceObject shared_key_pref_;
   ESPPreferenceObject keypad_name_pref_;
+  ESPPreferenceObject linked_lock_pref_;
 
   // ----- Runtime state -------------------------------------------------------
 
@@ -207,9 +257,23 @@ class SwitchbotKeypadBridge : public Component {
   psa_key_id_t aes_key_handle_{PSA_KEY_ID_NULL};
   LockState lock_state_{LockState::LOCKED};
 
-  // Per-connection encrypted-session state (token slot, IV, anti-replay,
-  // transport crypto). Only ever touched from the main task.
+  // Keypad encrypted-session state (token slot, IV, anti-replay, transport
+  // crypto). The IV may survive BLE reconnects when the keypad continues the
+  // same logical session. Only ever touched from the main task.
   LockSession session_{};
+
+  PhysicalLockClient physical_lock_client_{};
+  LinkedLockInfo linked_lock_info_{};
+  bool lock_linked_{false};
+  // True while the relay task owns physical_lock_client_ and the central
+  // role; battery scans defer to it.
+  std::atomic<bool> lock_relay_busy_{false};
+  // Relay outcome, written by the relay task and consumed by loop() for
+  // logging only. Fields are stable while the flag is false→true (single
+  // relay in flight, release/acquire pairing).
+  std::atomic<bool> pending_relay_apply_{false};
+  DecodedCommand relay_command_{};
+  bool           relay_ok_{false};
 
   // ----- Keypad battery state --------------------------------------------------
 
@@ -223,19 +287,31 @@ class SwitchbotKeypadBridge : public Component {
   // scan window?" gate — hence atomic.
   std::atomic<bool> battery_scan_active_{false};
   BatteryScanCallbacks *battery_scan_callbacks_{nullptr};
-  int last_battery_{-1};  // last published value; -1 = nothing published yet
+  std::atomic<bool> battery_scan_wants_keypad_{false};
+  std::atomic<bool> battery_scan_wants_lock_{false};
+  std::atomic<bool> keypad_battery_scan_found_{false};
+  std::atomic<bool> lock_battery_scan_found_{false};
+  std::atomic<bool> battery_scan_keypad_known_{false};
+  uint8_t battery_scan_keypad_mac_[6]{};
+  uint8_t battery_scan_keypad_family_{0};
+  uint8_t battery_scan_lock_mac_[6]{};
+  PhysicalLockModel battery_scan_lock_model_{PhysicalLockModel::UNKNOWN};
+  int last_keypad_battery_{-1};  // last published value; -1 = nothing published yet
+  int last_lock_battery_{-1};
 
   // Latest advert parsed by the NimBLE scan callback, handed to loop()
   // under rx_mutex_ (same pattern as the RX queue).
-  bool battery_advert_pending_{false};
-  int battery_advert_value_{-1};
-  uint8_t battery_advert_mac_[6]{};
-  uint8_t battery_advert_family_{0};
+  bool keypad_battery_advert_pending_{false};
+  int keypad_battery_advert_value_{-1};
+  uint8_t keypad_battery_advert_mac_[6]{};
+  uint8_t keypad_battery_advert_family_{0};
+  bool lock_battery_advert_pending_{false};
+  int lock_battery_advert_value_{-1};
 };
 
-// Home Assistant button that unpairs the keypad: forgets it, rotates the
-// shared key and re-opens the pairing wizard — all without a reboot.
-class UnpairButton : public button::Button, public Parented<SwitchbotKeypadBridge> {
+// Home Assistant reset button: forgets keypad and lock, rotates the shared key
+// and re-opens the setup wizard — all without a reboot.
+class ResetButton : public button::Button, public Parented<SwitchbotKeypadBridge> {
  protected:
   void press_action() override;
 };

--- a/switchbot-keypad-bridge.yaml
+++ b/switchbot-keypad-bridge.yaml
@@ -29,7 +29,7 @@ ota:
   - platform: esphome
     password: !secret ota_password
 
-# TLS in the pairing wizard needs a valid system clock; SNTP keeps it set
+# TLS in the setup wizard needs a valid system clock; SNTP keeps it set
 # even before Home Assistant connects.
 time:
   - platform: sntp
@@ -41,13 +41,19 @@ switchbot_keypad_bridge:
   keypad:
     name: "Keypad"
 
-  # Keypad battery, read from its BLE advertisement once per scan interval.
-  battery_level:
-    name: "Keypad Battery"
+  linked_lock:
+    name: "Lock"
+
+  # Keypad and linked lock battery are read from BLE advertisements by the
+  # shared background scan below.
+  keypad_battery_level:
+    name: "Keypad battery"
+  lock_battery_level:
+    name: "Lock battery"
   # battery_scan_interval: 15min
 
-  unpair_button:
-    name: "Unpair"
+  reset_button:
+    name: "Reset"
 
   on_unlock:
     # method: "pin" | "fingerprint" | "nfc" | "face" | "unknown"   index: credential slot

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,5 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+/secrets.yaml

--- a/tests/compile.wt32-eth01.yaml
+++ b/tests/compile.wt32-eth01.yaml
@@ -1,0 +1,46 @@
+esphome:
+  name: switchbot-keypad-bridge-test
+
+esp32:
+  board: wt32-eth01
+  framework:
+    type: esp-idf
+
+external_components:
+  - source: ../components
+    components: [switchbot_keypad_bridge]
+
+ethernet:
+  type: LAN8720
+  mdc_pin: GPIO23
+  mdio_pin: GPIO18
+  clk:
+    pin: GPIO0
+    mode: CLK_EXT_IN
+  phy_addr: 1
+  power_pin: GPIO16
+
+logger:
+  level: VERBOSE
+
+api:
+
+ota:
+  - platform: esphome
+
+time:
+  - platform: sntp
+
+switchbot_keypad_bridge:
+  keypad_action:
+    name: Action
+  keypad:
+    name: Keypad
+  linked_lock:
+    name: Lock
+  keypad_battery_level:
+    name: Keypad battery
+  lock_battery_level:
+    name: Lock battery
+  reset_button:
+    name: Reset

--- a/tests/lock_session_test.cpp
+++ b/tests/lock_session_test.cpp
@@ -1,0 +1,197 @@
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <string>
+#include <vector>
+
+#include "components/switchbot_keypad_bridge/aes_ctr.h"
+#include "components/switchbot_keypad_bridge/lock_session.h"
+
+namespace {
+
+using esphome::switchbot_keypad_bridge::CommandType;
+using esphome::switchbot_keypad_bridge::LockSession;
+
+constexpr psa_key_id_t TEST_KEY = 0x42;
+constexpr uint8_t SLOT = 0xC6;
+constexpr std::array<uint8_t, 4> STATE_POLL = {0x0F, 0x4F, 0x81, 0x00};
+constexpr std::array<uint8_t, 8> LOCK = {0x0F, 0x4E, 0x01, 0x03,
+                                         0x00, 0x00, 0x00, 0x00};
+constexpr std::array<uint8_t, 2> DOORBELL = {0x01, 0x03};
+
+std::deque<uint32_t> random_values;
+
+std::array<uint8_t, 16> make_iv(uint8_t first) {
+  std::array<uint8_t, 16> iv{};
+  for (size_t i = 0; i < iv.size(); ++i) {
+    iv[i] = static_cast<uint8_t>(first + i);
+  }
+  return iv;
+}
+
+void queue_iv(const std::array<uint8_t, 16> &iv) {
+  for (size_t i = 0; i < iv.size(); i += sizeof(uint32_t)) {
+    uint32_t word;
+    std::memcpy(&word, iv.data() + i, sizeof(word));
+    random_values.push_back(word);
+  }
+}
+
+std::string iv_request() {
+  const uint8_t bytes[8] = {0x57, 0x00, 0x00, 0x00, 0x0F, 0x21, 0x03, SLOT};
+  return {reinterpret_cast<const char *>(bytes), sizeof(bytes)};
+}
+
+std::array<uint8_t, 16> response_iv(const LockSession &session) {
+  std::array<uint8_t, 16> iv{};
+  std::memcpy(iv.data(), session.iv_response() + 4, iv.size());
+  return iv;
+}
+
+template<size_t N>
+std::string encrypted_frame(const std::array<uint8_t, 16> &iv,
+                            const std::array<uint8_t, N> &plaintext) {
+  std::vector<uint8_t> wire(LockSession::HEADER_LEN + plaintext.size());
+  wire[0] = 0x57;
+  wire[1] = SLOT;
+  wire[2] = iv[0];
+  wire[3] = iv[1];
+  const bool ok = esphome::switchbot_keypad_bridge::aes_ctr_xcrypt(
+      TEST_KEY, iv.data(), plaintext.data(), wire.data() + LockSession::HEADER_LEN,
+      plaintext.size());
+  assert(ok);
+  return {reinterpret_cast<const char *>(wire.data()), wire.size()};
+}
+
+void assert_response_uses_iv(LockSession &session,
+                             const std::array<uint8_t, 16> &iv) {
+  const uint8_t plaintext[3] = {0x81, 0x08, 0x08};
+  uint8_t packet[LockSession::MAX_PACKET]{};
+  const size_t size = session.encrypt_response(session.header(), plaintext,
+                                                sizeof(plaintext), packet);
+  assert(size == LockSession::HEADER_LEN + sizeof(plaintext));
+
+  uint8_t decoded[sizeof(plaintext)]{};
+  const bool ok = esphome::switchbot_keypad_bridge::aes_ctr_xcrypt(
+      TEST_KEY, iv.data(), packet + LockSession::HEADER_LEN, decoded,
+      sizeof(decoded));
+  assert(ok);
+  assert(std::memcmp(decoded, plaintext, sizeof(plaintext)) == 0);
+}
+
+void test_iv_handoff_and_replay() {
+  LockSession session;
+  session.set_aes_key(TEST_KEY);
+
+  const auto active_iv = make_iv(0x10);
+  queue_iv(active_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(response_iv(session) == active_iv);
+
+  const std::string active_poll = encrypted_frame(active_iv, STATE_POLL);
+  assert(session.process_frame(active_poll) == LockSession::Action::COMMAND);
+  assert(session.command().type == CommandType::STATE_POLL);
+
+  // A BLE reconnect clears only transient transport state. The logical crypto
+  // generation and its replay history stay alive.
+  session.reset_transport();
+  assert(session.process_frame(active_poll) == LockSession::Action::COMMAND);
+
+  const auto abandoned_pending_iv = make_iv(0x30);
+  queue_iv(abandoned_pending_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(response_iv(session) == abandoned_pending_iv);
+
+  // A second IV request replaces only pending_, never the still-active IV.
+  const auto pending_iv = make_iv(0x50);
+  queue_iv(pending_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(response_iv(session) == pending_iv);
+
+  // The reported Vision Pro race: finish an old state poll after advertising
+  // the next IV, and encrypt the reply with the old generation.
+  assert(session.process_frame(active_poll) == LockSession::Action::COMMAND);
+  assert(session.command().type == CommandType::STATE_POLL);
+  assert_response_uses_iv(session, active_iv);
+
+  // Only state polls may cross the hand-off boundary. Side effects remain
+  // rejected even if their ciphertext has not appeared in the replay ring.
+  assert(session.process_frame(encrypted_frame(active_iv, LOCK)) ==
+         LockSession::Action::NONE);
+
+  // A frame for an abandoned pending generation is neither active nor pending.
+  assert(session.process_frame(encrypted_frame(abandoned_pending_iv, STATE_POLL)) ==
+         LockSession::Action::NONE);
+
+  // The first frame under pending_ promotes it. Its replay entry moves with
+  // the context, so repeating the same state-changing ciphertext is rejected.
+  const std::string pending_lock = encrypted_frame(pending_iv, LOCK);
+  assert(session.process_frame(pending_lock) == LockSession::Action::COMMAND);
+  assert(session.command().type == CommandType::LOCK);
+  assert(session.process_frame(pending_lock) == LockSession::Action::NONE);
+
+  // The previous generation is gone once pending_ has been proven active.
+  assert(session.process_frame(active_poll) == LockSession::Action::NONE);
+
+  // Doorbell remains intentionally outside the side-effect replay filter.
+  const std::string doorbell = encrypted_frame(pending_iv, DOORBELL);
+  assert(session.process_frame(doorbell) == LockSession::Action::COMMAND);
+  assert(session.command().type == CommandType::DOORBELL);
+  assert(session.process_frame(doorbell) == LockSession::Action::COMMAND);
+
+  // A full crypto reset (unpair/re-key) rejects the formerly active IV.
+  session.reset();
+  assert(session.process_frame(encrypted_frame(pending_iv, STATE_POLL)) ==
+         LockSession::Action::NONE);
+}
+
+void test_seq_collision_is_resolved() {
+  LockSession session;
+  session.set_aes_key(TEST_KEY);
+
+  const auto active_iv = make_iv(0x70);
+  queue_iv(active_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(active_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  // Simulate a broken RNG returning the same IV for every bounded retry.
+  for (size_t i = 0; i < 5; ++i) {
+    queue_iv(active_iv);
+  }
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  const auto pending_iv = response_iv(session);
+  assert(pending_iv[0] != active_iv[0] || pending_iv[1] != active_iv[1]);
+}
+
+}  // namespace
+
+uint32_t esp_random() {
+  assert(!random_values.empty());
+  const uint32_t value = random_values.front();
+  random_values.pop_front();
+  return value;
+}
+
+namespace esphome {
+namespace switchbot_keypad_bridge {
+
+bool aes_ctr_xcrypt(psa_key_id_t key, const uint8_t iv[16],
+                    const uint8_t *input, uint8_t *output, size_t length) {
+  for (size_t i = 0; i < length; ++i) {
+    output[i] = input[i] ^ iv[i % 16] ^ static_cast<uint8_t>(key);
+  }
+  return true;
+}
+
+}  // namespace switchbot_keypad_bridge
+}  // namespace esphome
+
+int main() {
+  test_iv_handoff_and_replay();
+  test_seq_collision_is_resolved();
+  assert(random_values.empty());
+  return 0;
+}

--- a/tests/run_lock_session_tests.sh
+++ b/tests/run_lock_session_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+BIN="${TMPDIR:-/tmp}/switchbot-lock-session-test"
+CXX=${CXX:-c++}
+
+"$CXX" -std=c++17 -Wall -Wextra -Werror \
+  -I"$ROOT/tests/stubs" -I"$ROOT" \
+  "$ROOT/components/switchbot_keypad_bridge/lock_session.cpp" \
+  "$ROOT/components/switchbot_keypad_bridge/lock_protocol.cpp" \
+  "$ROOT/tests/lock_session_test.cpp" \
+  -o "$BIN"
+
+"$BIN"

--- a/tests/stubs/esp_random.h
+++ b/tests/stubs/esp_random.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <cstdint>
+
+uint32_t esp_random();

--- a/tests/stubs/esphome/core/helpers.h
+++ b/tests/stubs/esphome/core/helpers.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+inline std::string format_hex_pretty(const uint8_t *, size_t) { return {}; }

--- a/tests/stubs/esphome/core/log.h
+++ b/tests/stubs/esphome/core/log.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#define ESP_LOGV(tag, format, ...) do { (void) (tag); } while (0)
+#define ESP_LOGD(tag, format, ...) do { (void) (tag); } while (0)
+#define ESP_LOGI(tag, format, ...) do { (void) (tag); } while (0)
+#define ESP_LOGW(tag, format, ...) do { (void) (tag); } while (0)
+#define ESP_LOGE(tag, format, ...) do { (void) (tag); } while (0)

--- a/tests/stubs/psa/crypto.h
+++ b/tests/stubs/psa/crypto.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <cstdint>
+
+using psa_key_id_t = uint32_t;
+
+#define PSA_KEY_ID_NULL 0


### PR DESCRIPTION
## Summary

Adds optional bridge-to-physical-lock support to SwitchBot Keypad Bridge.

The bridge can now link a real SwitchBot Lock during the setup wizard, provision the shared keypad/lock key into the lock, persist the linked lock identity, and relay keypad lock/unlock payloads to the physical lock while still responding to the keypad locally.

## What changed

- Added physical lock BLE client support, including AES-CTR/AES-GCM encrypted sessions.
- Added lock linking flow to the setup wizard.
- Added shared background job infrastructure for keypad pairing and lock linking tasks.
- Added linked lock persistence and reset handling.
- Added local keypad response first, with physical lock relay running in the background.
- Added linked lock and lock battery sensors.
- Updated ESPHome config schema:
  - `linked_lock`
  - `keypad_battery_level`
  - `lock_battery_level`
  - `reset_button`
- Updated README and sample YAML for the new setup flow.

## Behavior notes
With a linked physical lock, keypad responses remain local and immediate. Side-effecting commands are relayed to the physical lock in the background, and the lock reply is used only for relay logging.