### PR TITLE
perf: reduce linked-lock relay latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,14 @@ switchbot_keypad_bridge:
   models from the cloud device type, uses the lock communication key only as a
   transient setup key to provision the shared keypad/lock key, then verifies
   that shared slot. Each relayed command opens a short BLE connection and
-  disconnects again using the shared key.
+  disconnects again using the shared key. The disconnected NimBLE client keeps
+  its discovered GATT database, so subsequent actions skip service discovery
+  without keeping the lock awake between commands. When the keypad wakes, the
+  bridge opens that cached lock connection in parallel with authentication and
+  closes it on keypad disconnect or a 10-second safety timeout. This overlaps
+  the two BLE hops without an always-on connection. Runtime relay also uses a
+  short BLE connection interval and unacknowledged GATT writes (the same write
+  mode used by pySwitchbot); pairing retains acknowledged writes for safety.
 - **Key hygiene** — reset rotates the shared keypad/lock session key and clears
   the linked lock record, so a previously linked keypad can no longer command
   the bridge.

--- a/components/switchbot_keypad_bridge/physical_lock.cpp
+++ b/components/switchbot_keypad_bridge/physical_lock.cpp
@@ -8,6 +8,7 @@
 #include <freertos/semphr.h>
 
 #include "esphome/core/helpers.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 #include "aes_ctr.h"
 #include "ble_utils.h"
@@ -22,6 +23,15 @@ const char *const TAG = "switchbot_keypad_bridge.lock";
 
 constexpr uint8_t PROTOCOL_MAGIC = 0x57;
 constexpr size_t WIRE_HEADER_LEN = 4;
+
+// BLE units: interval is 1.25 ms and supervision timeout is 10 ms. These
+// values keep the short relay session responsive without changing idle power
+// (the link is still disconnected immediately after each command).
+constexpr uint16_t LOW_LATENCY_INTERVAL_MIN = 12;  // 15 ms
+constexpr uint16_t LOW_LATENCY_INTERVAL_MAX = 24;  // 30 ms
+constexpr uint16_t LOW_LATENCY_SUPERVISION_TIMEOUT = 400;  // 4 s
+constexpr uint16_t CONNECT_SCAN_INTERVAL = 16;  // 10 ms
+constexpr uint16_t CONNECT_SCAN_WINDOW = 16;    // continuous while connecting
 
 struct NotifyWaiter {
   SemaphoreHandle_t sem{nullptr};
@@ -259,8 +269,7 @@ bool PhysicalLockClient::send_plaintext_sequence(
   NotifyWaiter waiter;
   waiter.sem = xSemaphoreCreateBinary();
   if (waiter.sem == nullptr) {
-    client->disconnect();
-    NimBLEDevice::deleteClient(client);
+    this->release_connection_(config, client);
     error_out = "Could not allocate lock notification semaphore.";
     return false;
   }
@@ -270,10 +279,12 @@ bool PhysicalLockClient::send_plaintext_sequence(
                                size_t length, bool /*is_notify*/) {
                        waiter.value.assign(reinterpret_cast<const char *>(data), length);
                        xSemaphoreGive(waiter.sem);
-                     })) {
+                     }, /*response=*/!config.low_latency_io)) {
     vSemaphoreDelete(waiter.sem);
-    client->disconnect();
-    NimBLEDevice::deleteClient(client);
+    this->release_connection_(config, client);
+    if (config.reuse_gatt_cache && client == this->cached_client_) {
+      this->clear_connection_cache();
+    }
     error_out = "Could not subscribe to lock notifications.";
     return false;
   }
@@ -283,7 +294,8 @@ bool PhysicalLockClient::send_plaintext_sequence(
   std::string notify;
   if (progress) progress(Phase::SESSION);
   uint8_t iv_req[8] = {PROTOCOL_MAGIC, 0x00, 0x00, 0x00, 0x0F, 0x21, 0x03, config.key_id};
-  if (!rx->writeValue(iv_req, sizeof(iv_req), /*response=*/true)) {
+  if (!rx->writeValue(iv_req, sizeof(iv_req),
+                      /*response=*/!config.low_latency_io)) {
     error_out = "Could not request a lock encryption session.";
   } else if (!wait_notify(waiter, 3000, notify)) {
     error_out = "Lock did not open an encryption session.";
@@ -313,11 +325,36 @@ bool PhysicalLockClient::send_plaintext_sequence(
     }
   }
 
-  tx->unsubscribe();
+  tx->unsubscribe(/*response=*/false);
   vSemaphoreDelete(waiter.sem);
-  client->disconnect();
-  NimBLEDevice::deleteClient(client);
+  this->release_connection_(config, client);
   return ok;
+}
+
+bool PhysicalLockClient::preconnect(const Config &config, std::string &error_out,
+                                    const ProgressCallback &progress) {
+  if (!config.reuse_gatt_cache) {
+    error_out = "Lock preconnect requires the reconnect cache.";
+    return false;
+  }
+  NimBLEClient *client = nullptr;
+  NimBLERemoteCharacteristic *rx = nullptr;
+  NimBLERemoteCharacteristic *tx = nullptr;
+  if (!this->connect_(config, client, rx, tx, error_out, progress)) {
+    return false;
+  }
+  if (client != this->cached_client_ || rx == nullptr || tx == nullptr) {
+    this->release_connection_(config, client);
+    error_out = "Lock preconnect did not retain a reusable GATT client.";
+    return false;
+  }
+  return true;
+}
+
+void PhysicalLockClient::disconnect_preconnected() {
+  if (this->cached_client_ != nullptr && this->cached_client_->isConnected()) {
+    this->cached_client_->disconnect();
+  }
 }
 
 bool PhysicalLockClient::provision_and_verify_shared_key(
@@ -462,6 +499,34 @@ bool PhysicalLockClient::connect_(const Config &config, NimBLEClient *&client,
                                   NimBLERemoteCharacteristic *&tx,
                                   std::string &error_out,
                                   const ProgressCallback &progress) {
+  const uint32_t connect_started_at = millis();
+
+  // A short preconnect may already have opened the link while the keypad was
+  // authenticating. Reuse it directly; no reconnect, discovery or idle wait.
+  const bool warm =
+      config.reuse_gatt_cache && this->cached_client_ != nullptr &&
+      this->cached_client_mac_ == upper_mac(config.mac) &&
+      this->cached_client_->isConnected();
+  if (warm) {
+    NimBLERemoteService *svc = this->cached_client_->getService(
+        NimBLEUUID(SWITCHBOT_SERVICE_UUID));
+    NimBLERemoteCharacteristic *warm_rx = nullptr;
+    NimBLERemoteCharacteristic *warm_tx = nullptr;
+    if (svc != nullptr) {
+      warm_rx = svc->getCharacteristic(NimBLEUUID(SWITCHBOT_RX_CHAR_UUID));
+      warm_tx = svc->getCharacteristic(NimBLEUUID(SWITCHBOT_TX_CHAR_UUID));
+    }
+    if (warm_rx != nullptr && warm_tx != nullptr) {
+      client = this->cached_client_;
+      rx = warm_rx;
+      tx = warm_tx;
+      ESP_LOGD(TAG, "Lock BLE ready in %u ms (preconnected)",
+               static_cast<unsigned>(millis() - connect_started_at));
+      return true;
+    }
+    this->clear_connection_cache();
+  }
+
   // Two attempts at most: the first connects straight to the last cached
   // advertisement address — or, fresh after boot, to the address rebuilt
   // from the stored MAC — skipping the ~2.5 s discovery scan entirely. Only
@@ -482,6 +547,57 @@ bool PhysicalLockClient::connect_(const Config &config, NimBLEClient *&client,
     }
 
     if (progress) progress(Phase::CONNECT);
+
+    // Reuse the same disconnected client for relay traffic. NimBLE keeps the
+    // remote attribute database on the client, and deleteAttributes=false
+    // skips GATT discovery on a known peer. The actual BLE link is still
+    // closed after every command, so the lock does not stay awake while idle.
+    const bool reusable =
+        config.reuse_gatt_cache && this->cached_client_ != nullptr &&
+        this->cached_client_mac_ == upper_mac(config.mac) &&
+        !this->cached_client_->isConnected();
+    if (reusable) {
+      this->cached_client_->setConnectTimeout(5000);
+      if (config.low_latency_io) {
+        this->cached_client_->setConnectionParams(
+            LOW_LATENCY_INTERVAL_MIN, LOW_LATENCY_INTERVAL_MAX, 0,
+            LOW_LATENCY_SUPERVISION_TIMEOUT, CONNECT_SCAN_INTERVAL,
+            CONNECT_SCAN_WINDOW);
+      }
+      if (this->cached_client_->connect(target, /*deleteAttributes=*/false,
+                                        /*asyncConnect=*/false,
+                                        /*exchangeMTU=*/false)) {
+        NimBLERemoteService *svc = this->cached_client_->getService(
+            NimBLEUUID(SWITCHBOT_SERVICE_UUID));
+        NimBLERemoteCharacteristic *cached_rx = nullptr;
+        NimBLERemoteCharacteristic *cached_tx = nullptr;
+        if (svc != nullptr) {
+          cached_rx = svc->getCharacteristic(NimBLEUUID(SWITCHBOT_RX_CHAR_UUID));
+          cached_tx = svc->getCharacteristic(NimBLEUUID(SWITCHBOT_TX_CHAR_UUID));
+        }
+        if (cached_rx != nullptr && cached_tx != nullptr) {
+          client = this->cached_client_;
+          rx = cached_rx;
+          tx = cached_tx;
+          this->cached_addr_ = target;
+          this->cached_mac_ = config.mac;
+          ESP_LOGD(TAG, "Lock BLE ready in %u ms (cached GATT)",
+                   static_cast<unsigned>(millis() - connect_started_at));
+          return true;
+        }
+        this->cached_client_->disconnect();
+      }
+
+      // The peer may have changed firmware or invalidated its handles. Drop
+      // the stale client once and let the normal discovery fallback rebuild
+      // a clean cache below.
+      this->clear_connection_cache();
+      if (attempt == 0) {
+        this->cached_mac_.clear();
+        continue;
+      }
+    }
+
     SwitchbotGattConnection conn;
     if (!connect_switchbot_service(target, 5000, "physical lock", conn, error_out)) {
       if (attempt == 0) {
@@ -495,12 +611,51 @@ bool PhysicalLockClient::connect_(const Config &config, NimBLEClient *&client,
     client = conn.client;
     rx = conn.rx;
     tx = conn.tx;
+    if (config.low_latency_io) {
+      // Fresh clients connect with NimBLE's conservative defaults. Apply the
+      // faster interval for the encryption/command exchange; cached reconnects
+      // use the same values from their first connection request.
+      client->updateConnParams(LOW_LATENCY_INTERVAL_MIN,
+                               LOW_LATENCY_INTERVAL_MAX, 0,
+                               LOW_LATENCY_SUPERVISION_TIMEOUT);
+    }
     this->cached_addr_ = target;
     this->cached_mac_  = config.mac;
+    if (config.reuse_gatt_cache) {
+      this->cached_client_ = client;
+      this->cached_client_mac_ = upper_mac(config.mac);
+      ESP_LOGD(TAG, "Lock BLE ready in %u ms (fresh GATT; cached for reconnect)",
+               static_cast<unsigned>(millis() - connect_started_at));
+    }
     return true;
   }
   error_out = "Could not connect to the physical lock.";
   return false;
+}
+
+void PhysicalLockClient::release_connection_(const Config &config,
+                                             NimBLEClient *client) {
+  if (client == nullptr) return;
+  if (client->isConnected()) {
+    client->disconnect();
+  }
+  if (config.reuse_gatt_cache && client == this->cached_client_) {
+    return;
+  }
+  NimBLEDevice::deleteClient(client);
+}
+
+void PhysicalLockClient::clear_connection_cache() {
+  if (this->cached_client_ != nullptr) {
+    if (this->cached_client_->isConnected()) {
+      this->cached_client_->disconnect();
+    }
+    NimBLEDevice::deleteClient(this->cached_client_);
+    this->cached_client_ = nullptr;
+  }
+  this->cached_client_mac_.clear();
+  this->cached_addr_ = NimBLEAddress{};
+  this->cached_mac_.clear();
 }
 
 bool PhysicalLockClient::parse_session_response_(const std::string &wire,
@@ -564,7 +719,8 @@ bool PhysicalLockClient::send_encrypted_(const Config &config, const Session &se
 
   ESP_LOGV(TAG, "TX lock %s",
            format_hex_pretty(frame.data(), frame.size()).c_str());
-  if (!rx->writeValue(frame.data(), frame.size(), /*response=*/true)) {
+  if (!rx->writeValue(frame.data(), frame.size(),
+                      /*response=*/!config.low_latency_io)) {
     error_out = "Could not write encrypted command to the lock.";
     return false;
   }

--- a/components/switchbot_keypad_bridge/physical_lock.h
+++ b/components/switchbot_keypad_bridge/physical_lock.h
@@ -34,6 +34,14 @@ class PhysicalLockClient {
     PhysicalLockModel model{PhysicalLockModel::UNKNOWN};
     uint8_t key_id{0};
     std::array<uint8_t, 16> key{};
+    // Keep the disconnected NimBLE client and its discovered GATT database
+    // between relay calls. This avoids repeating service discovery without
+    // keeping the physical lock connected (and therefore awake) while idle.
+    bool reuse_gatt_cache{false};
+    // Runtime relay only: request a shorter connection interval and use GATT
+    // writes without response, matching pySwitchbot's command path. Pairing
+    // and key provisioning keep their conservative acknowledged writes.
+    bool low_latency_io{false};
   };
 
   // Coarse progress of one encrypted exchange, reported through the optional
@@ -73,6 +81,16 @@ class PhysicalLockClient {
                                const ProgressCallback &progress = nullptr,
                                const ResponseCallback &response_callback = nullptr);
 
+  // Open the BLE/GATT path without starting an encryption session. The bridge
+  // calls this only after a keypad wakes up, so lock connection latency can
+  // overlap keypad authentication without holding the lock awake while idle.
+  bool preconnect(const Config &config, std::string &error_out,
+                  const ProgressCallback &progress = nullptr);
+
+  // Close a connection left open by preconnect(). The disconnected client and
+  // discovered GATT database remain cached when reuse_gatt_cache is enabled.
+  void disconnect_preconnected();
+
   // Provision the keypad/lock shared key with the lock's cloud credential,
   // then verify the freshly-written shared slot on the same BLE connection.
   bool provision_and_verify_shared_key(
@@ -84,6 +102,11 @@ class PhysicalLockClient {
       const ProgressCallback &provision_progress = nullptr,
       const CommandProgressCallback &provision_command_progress = nullptr,
       const ProgressCallback &verify_progress = nullptr);
+
+  // Drop any retained disconnected client/GATT database. Call this when the
+  // linked lock changes or pairing is reset so stale handles are never reused
+  // for another device.
+  void clear_connection_cache();
 
  private:
   enum class CryptoMode : uint8_t { CTR, GCM };
@@ -99,6 +122,7 @@ class PhysicalLockClient {
                 NimBLERemoteCharacteristic *&tx,
                 std::string &error_out,
                 const ProgressCallback &progress);
+  void release_connection_(const Config &config, NimBLEClient *client);
   bool parse_session_response_(const std::string &wire, Session &session,
                                std::string &error_out);
   bool send_encrypted_(const Config &config, const Session &session,
@@ -114,6 +138,13 @@ class PhysicalLockClient {
   // through it fails (the next attempt re-scans).
   NimBLEAddress cached_addr_{};
   std::string   cached_mac_;
+
+  // A disconnected NimBLE client retains the peer's discovered services and
+  // characteristic handles. Reconnecting it with deleteAttributes=false is
+  // substantially faster than creating and discovering a fresh client, while
+  // drawing no connection-event power between commands.
+  NimBLEClient *cached_client_{nullptr};
+  std::string   cached_client_mac_;
 };
 
 }  // namespace switchbot_keypad_bridge

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
@@ -262,14 +262,20 @@ void SwitchbotKeypadBridge::loop() {
     if (ev.type == QueuedEvent::CONNECT) {
       ESP_LOGI(TAG, "Keypad connected");
       this->session_.reset_transport();
+      this->lock_prewarm_close_pending_ = false;
+      this->lock_prewarm_close_at_ = millis() + 10000;
+      this->start_lock_prewarm_async_();
     } else if (ev.type == QueuedEvent::DISCONNECT) {
       ESP_LOGI(TAG, "Keypad disconnected, restarting advertising");
       this->session_.reset_transport();
+      this->lock_prewarm_close_pending_ = true;
       NimBLEDevice::startAdvertising();
     } else if (ev.type == QueuedEvent::RX) {
       this->on_rx_frame_(ev.frame);
     }
   }
+
+  this->maybe_close_lock_prewarm_();
 
   if (this->keypad_battery_level_sensor_ != nullptr ||
       this->lock_battery_level_sensor_ != nullptr) {
@@ -315,6 +321,14 @@ void SwitchbotKeypadBridge::apply_pending_pairing_() {
 
 void SwitchbotKeypadBridge::apply_pending_lock_link_() {
   if (this->pending_lock_apply_.exchange(false, std::memory_order_acquire)) {
+    if (this->lock_relay_busy_.load(std::memory_order_acquire) ||
+        this->lock_prewarm_busy_.load(std::memory_order_acquire)) {
+      this->pending_lock_apply_.store(true, std::memory_order_release);
+      return;
+    }
+    // The peer and its GATT handles may be changing. Never carry the previous
+    // lock's reconnect cache across a new link operation.
+    this->physical_lock_client_.clear_connection_cache();
     LinkedLockInfo info{};
     if (parse_mac_pretty(this->pending_lock_mac_, info.mac)) {
       info.valid = 1;
@@ -634,6 +648,8 @@ PhysicalLockClient::Config SwitchbotKeypadBridge::physical_lock_config_(uint8_t 
     cfg.model = static_cast<PhysicalLockModel>(this->linked_lock_info_.model);
     cfg.key_id = slot_id;
     cfg.key = this->shared_key_;
+    cfg.reuse_gatt_cache = true;
+    cfg.low_latency_io = true;
   }
   return cfg;
 }
@@ -669,6 +685,14 @@ bool SwitchbotKeypadBridge::relay_to_lock_async_(const FrameHeader &header,
   BaseType_t rc = xTaskCreatePinnedToCore(
       [](void *raw) {
         auto *c = static_cast<RelayCtx *>(raw);
+        // A keypad-connect task may still be opening the same physical link.
+        // Wait for that one owner, then consume its already-open connection.
+        const TickType_t wait_started = xTaskGetTickCount();
+        const TickType_t wait_limit = pdMS_TO_TICKS(14000);
+        while (c->self->lock_prewarm_busy_.load(std::memory_order_acquire) &&
+               (xTaskGetTickCount() - wait_started) < wait_limit) {
+          vTaskDelay(pdMS_TO_TICKS(10));
+        }
         std::vector<uint8_t> response;
         std::string error;
         bool result_posted = false;
@@ -678,15 +702,20 @@ bool SwitchbotKeypadBridge::relay_to_lock_async_(const FrameHeader &header,
           c->self->pending_relay_apply_.store(true, std::memory_order_release);
           result_posted = true;
         };
-        const bool ok = c->self->physical_lock_client_.send_plaintext(
-            c->cfg, c->plaintext.data(), c->plaintext.size(), response, error,
-            nullptr,
-            [&post_relay_result](const std::vector<uint8_t> &reply) {
-              // The keypad already got its local response. This callback only
-              // lets loop() log that the physical lock replied.
-              (void) reply;
-              post_relay_result(true);
-            });
+        bool ok = false;
+        if (c->self->lock_prewarm_busy_.load(std::memory_order_acquire)) {
+          error = "Timed out waiting for the lock preconnect task.";
+        } else {
+          ok = c->self->physical_lock_client_.send_plaintext(
+              c->cfg, c->plaintext.data(), c->plaintext.size(), response, error,
+              nullptr,
+              [&post_relay_result](const std::vector<uint8_t> &reply) {
+                // The keypad already got its local response. This callback only
+                // lets loop() log that the physical lock replied.
+                (void) reply;
+                post_relay_result(true);
+              });
+        }
         if (!ok) {
           ESP_LOGW(TAG, "Lock relay command failed: %s", error.c_str());
         }
@@ -710,6 +739,60 @@ bool SwitchbotKeypadBridge::relay_to_lock_async_(const FrameHeader &header,
     return false;
   }
   return true;
+}
+
+void SwitchbotKeypadBridge::start_lock_prewarm_async_() {
+  if (!this->lock_linked_ || this->linked_lock_info_.valid == 0 ||
+      this->lock_relay_busy_.load(std::memory_order_acquire) ||
+      this->lock_prewarm_busy_.exchange(true, std::memory_order_acq_rel)) {
+    return;
+  }
+
+  this->stop_battery_scan_();
+  struct PrewarmCtx {
+    SwitchbotKeypadBridge *self;
+    PhysicalLockClient::Config cfg;
+  };
+  auto *ctx = new PrewarmCtx{
+      this, this->physical_lock_config_(this->linked_lock_info_.slot_id)};
+  BaseType_t rc = xTaskCreatePinnedToCore(
+      [](void *raw) {
+        auto *c = static_cast<PrewarmCtx *>(raw);
+        std::string error;
+        const uint32_t started_at = millis();
+        if (c->self->physical_lock_client_.preconnect(c->cfg, error)) {
+          ESP_LOGD(TAG, "Lock preconnected after keypad wake in %u ms",
+                   static_cast<unsigned>(millis() - started_at));
+        } else {
+          // Relay still gets its normal connect+fallback attempt; prewarm is
+          // opportunistic and must never turn a recoverable miss into failure.
+          ESP_LOGD(TAG, "Lock preconnect skipped: %s", error.c_str());
+        }
+        c->self->lock_prewarm_busy_.store(false, std::memory_order_release);
+        delete c;
+        vTaskDelete(nullptr);
+      },
+      "lock-prewarm", 6144, ctx, tskIDLE_PRIORITY + 2, nullptr, 0);
+  if (rc != pdPASS) {
+    delete ctx;
+    this->lock_prewarm_busy_.store(false, std::memory_order_release);
+    ESP_LOGD(TAG, "Could not start lock preconnect task");
+  }
+}
+
+void SwitchbotKeypadBridge::maybe_close_lock_prewarm_() {
+  const bool expired = this->lock_prewarm_close_at_ != 0 &&
+      static_cast<int32_t>(millis() - this->lock_prewarm_close_at_) >= 0;
+  if (!this->lock_prewarm_close_pending_ && !expired) {
+    return;
+  }
+  if (this->lock_relay_busy_.load(std::memory_order_acquire) ||
+      this->lock_prewarm_busy_.load(std::memory_order_acquire)) {
+    return;
+  }
+  this->physical_lock_client_.disconnect_preconnected();
+  this->lock_prewarm_close_pending_ = false;
+  this->lock_prewarm_close_at_ = 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -1024,6 +1107,7 @@ void SwitchbotKeypadBridge::stop_battery_scan_() {
 bool SwitchbotKeypadBridge::background_ble_busy_() const {
   return this->pairing_ui_.is_running() ||
          this->lock_relay_busy_.load(std::memory_order_relaxed) ||
+         this->lock_prewarm_busy_.load(std::memory_order_relaxed) ||
          (this->server_ != nullptr && this->server_->getConnectedCount() > 0);
 }
 

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
@@ -155,6 +155,10 @@ class SwitchbotKeypadBridge : public Component {
   // one-shot background task. The keypad is never answered from this path;
   // relay completion is logged only.
   bool relay_to_lock_async_(const FrameHeader &header, const DecodedCommand &command);
+  // Starts a short central connection as soon as the keypad wakes, overlapping
+  // the lock's BLE setup with keypad authentication. It never runs while idle.
+  void start_lock_prewarm_async_();
+  void maybe_close_lock_prewarm_();
   PhysicalLockClient::Config physical_lock_config_(uint8_t slot_id) const;
 
   // ----- Transport helpers ---------------------------------------------------
@@ -268,6 +272,11 @@ class SwitchbotKeypadBridge : public Component {
   // True while the relay task owns physical_lock_client_ and the central
   // role; battery scans defer to it.
   std::atomic<bool> lock_relay_busy_{false};
+  // Prewarm has separate ownership. Relay waits for it to finish, then reuses
+  // the connection; main-loop cleanup only runs when both flags are clear.
+  std::atomic<bool> lock_prewarm_busy_{false};
+  bool lock_prewarm_close_pending_{false};
+  uint32_t lock_prewarm_close_at_{0};
   // Relay outcome, written by the relay task and consumed by loop() for
   // logging only. Fields are stable while the flag is false→true (single
   // relay in flight, release/acquire pairing).


### PR DESCRIPTION
Hi, and thank you for building this project! I ran into the same delay described in #24 while using the physical lock relay. With the keypad linked directly to the lock, the response feels almost immediate, but through the bridge I was sometimes waiting several seconds before the lock reacted. I first wondered whether the delay came from a cloud round trip, so I spent some time testing each part of the flow on my M5Stack ATOM Lite. The main wait turned out to be establishing the BLE connection to the lock. This PR is my attempt to make the relay feel closer to the native connection without keeping the lock connected all the time.

## Summary

- Reuse the disconnected NimBLE client and its discovered GATT database so later relay actions can skip service discovery.
- Preconnect to the linked physical lock when the keypad connects, overlapping lock connection setup with keypad authentication.
- Request a 15–30 ms connection interval and use write-without-response for runtime lock commands. Pairing and provisioning continue to use acknowledged writes.
- Disconnect after each command, keypad disconnect, or a 10-second safety timeout, so the lock is not kept connected while idle.
- Serialize relay, prewarm, link updates, and battery scans to avoid concurrent BLE ownership races.

## Motivation

The current relay path begins establishing the lock connection only after the keypad action has been decrypted, which can add several seconds. This is intended to reduce the delay reported in #24 while preserving the bridge's low-power idle behavior.

## Validation

- `./tests/run_lock_session_tests.sh`
- Full ESPHome compile with `tests/compile.wt32-eth01.yaml`
- OTA and repeated hardware tests on an M5Stack ATOM Lite, SwitchBot Keypad, and SwitchBot Lock Ultra
- Pairing and link information persisted across OTA and reboots
- In a cached and prewarmed run, fingerprint event to lock confirmation measured about 1.83 seconds; the command exchange after the lock connection was ready was about 0.2 seconds
- BLE connection acceptance remains variable and is still the main source of residual latency

## AI assistance disclosure

This contribution was developed and iterated entirely through OpenAI Codex. I provided the requirements, hardware access, test actions, and validated the results on my devices; Codex produced and modified the code and documentation.