### PR TITLE
fix: preserve Vision Fast Unlock actions across IV rotation

### DIFF
--- a/components/switchbot_keypad_bridge/lock_session.cpp
+++ b/components/switchbot_keypad_bridge/lock_session.cpp
@@ -17,6 +17,7 @@ const char *const TAG = "switchbot_keypad_bridge.session";
 
 // Encrypted protocol framing.
 constexpr uint8_t PROTOCOL_MAGIC = 0x57;
+constexpr uint8_t VISION_KEY_SLOT = 0xC6;
 
 // Session IV negotiation. Most keypads send this after connect; some reconnect
 // and continue with the IV they already have.
@@ -30,10 +31,18 @@ constexpr size_t IV_RESPONSE_HEADER = 4;  // iv_response_ prefix before the IV b
 void LockSession::reset() {
   this->active_ = CryptoContext{};
   this->pending_ = CryptoContext{};
+  this->retired_ = CryptoContext{};
   this->reset_transport();
 }
 
 void LockSession::reset_transport() {
+  this->clear_transient_();
+  this->retired_ = CryptoContext{};
+  this->active_.late_action_allowed = false;
+  this->active_.handoff_poll_seen = false;
+}
+
+void LockSession::clear_transient_() {
   this->plaintext_size_ = 0;
   this->header_ = FrameHeader{};
   this->command_ = DecodedCommand{};
@@ -43,7 +52,7 @@ void LockSession::reset_transport() {
 LockSession::Action LockSession::process_frame(const std::string &frame) {
   // Never expose stale decoded bytes or a stale response IV after a dropped
   // frame. The bridge may relay plaintext asynchronously after COMMAND.
-  this->reset_transport();
+  this->clear_transient_();
 
   ESP_LOGV(TAG, "RX WIRE %zu bytes: %s", frame.size(),
            format_hex_pretty(reinterpret_cast<const uint8_t *>(frame.data()), frame.size()).c_str());
@@ -55,12 +64,18 @@ LockSession::Action LockSession::process_frame(const std::string &frame) {
     const uint8_t requested_slot = static_cast<uint8_t>(frame[7]);
     if (requested_slot != this->slot_id_) {
       ESP_LOGI(TAG, "Token slot: 0x%02X", requested_slot);
+      // Crypto contexts are not bound to the key_id byte carried outside the
+      // ciphertext. Treat a slot change as a hard session boundary so neither
+      // an active, pending nor retired IV can be relabelled for the new slot.
+      this->active_ = CryptoContext{};
+      this->pending_ = CryptoContext{};
+      this->retired_ = CryptoContext{};
       this->slot_id_ = requested_slot;
     }
     ESP_LOGD(TAG, "IV request");
     // Do not overwrite active_ yet. Vision-family keypads can send a delayed
     // state poll from the previous generation after requesting the next IV.
-    this->rotate_pending_iv_();
+    this->ensure_pending_iv_();
     return Action::SEND_IV;
   }
 
@@ -87,19 +102,34 @@ LockSession::Action LockSession::process_frame(const std::string &frame) {
   }
 
   // The protocol echoes IV[0..1] as seq_a/seq_b. Prefer pending_ when the
-  // keypad has switched; otherwise retain active_ just long enough to finish
-  // an in-flight poll. rotate_pending_iv_() guarantees their seq pairs differ.
+  // keypad has switched, then active_, then the one short-lived predecessor
+  // retained for the Fast Unlock race. Valid contexts always have distinct
+  // seq pairs and pending_/retired_ never coexist.
   const bool uses_pending = this->seq_matches_(this->pending_, this->header_);
   const bool uses_active = this->seq_matches_(this->active_, this->header_);
-  if (!uses_pending && !uses_active) {
+  const bool uses_retired = this->seq_matches_(this->retired_, this->header_);
+  if (!uses_pending && !uses_active && !uses_retired) {
     ESP_LOGW(TAG, "Dropping frame: seq_a/seq_b mismatch (cross-session replay?)");
     return Action::NONE;
   }
-  CryptoContext &context = uses_pending ? this->pending_ : this->active_;
+
+  // After pending_ was promoted by a poll, retired_ is eligible for exactly
+  // the next valid encrypted frame. Seeing the current generation first is a
+  // deterministic proof that the predecessor hand-off has ended.
+  if (uses_active && this->retired_.valid) {
+    ESP_LOGV(TAG, "Current IV observed; closing predecessor hand-off");
+    this->retired_ = CryptoContext{};
+  }
+  CryptoContext &context = uses_pending ? this->pending_
+                           : uses_active ? this->active_
+                                         : this->retired_;
 
   const size_t ct_len = frame.size() - HEADER_LEN;
   if (ct_len > MAX_PAYLOAD) {
     ESP_LOGW(TAG, "Dropping frame with invalid payload length: %zu", ct_len);
+    if (uses_retired) {
+      this->retired_ = CryptoContext{};
+    }
     return Action::NONE;
   }
 
@@ -114,6 +144,9 @@ LockSession::Action LockSession::process_frame(const std::string &frame) {
 
   uint8_t plaintext[MAX_PAYLOAD];
   if (!this->xcrypt_(context.iv, ciphertext, ct_len, plaintext)) {
+    if (uses_retired) {
+      this->retired_ = CryptoContext{};
+    }
     return Action::NONE;  // error already logged
   }
 
@@ -121,15 +154,48 @@ LockSession::Action LockSession::process_frame(const std::string &frame) {
 
   this->command_ = decode_lock_command(plaintext, ct_len);
 
-  // Once a new IV has been advertised, the superseded generation is accepted
-  // only for an idempotent state poll that was already in flight. In
-  // particular, never let a delayed/captured lock or unlock cross the IV
-  // boundary even if its ciphertext was not present in the small replay ring.
-  if (!uses_pending && this->pending_.valid &&
-      this->command_.type != CommandType::STATE_POLL) {
-    ESP_LOGW(TAG, "Dropping non-poll frame under superseded IV");
-    this->command_ = DecodedCommand{};
-    return Action::NONE;
+  // Fast Unlock on Vision periodically rotates the IV while an unlock can
+  // already be in flight under the predecessor. Admit one known UNLOCK before
+  // or immediately after a state poll promotes pending_. This allowance is
+  // bounded only by protocol events: no wall-clock timeout is involved.
+  const bool uses_predecessor =
+      uses_retired || (uses_active && this->pending_.valid);
+  const bool has_known_unlock_method =
+      this->command_.method == UnlockMethod::PIN ||
+      this->command_.method == UnlockMethod::NFC ||
+      this->command_.method == UnlockMethod::FINGERPRINT ||
+      this->command_.method == UnlockMethod::FACE;
+  const bool is_fast_unlock_action =
+      this->command_.type == CommandType::UNLOCK && has_known_unlock_method;
+
+  // While pending_ is uncommitted, tolerate one already-in-flight poll under
+  // active_. A second such poll proves the overlap has advanced without an
+  // unlock and deterministically closes the allowance.
+  if (uses_active && this->pending_.valid &&
+      this->command_.type == CommandType::STATE_POLL &&
+      context.late_action_allowed) {
+    if (context.handoff_poll_seen) {
+      context.late_action_allowed = false;
+      ESP_LOGV(TAG, "Second predecessor poll closed hand-off allowance");
+    } else {
+      context.handoff_poll_seen = true;
+    }
+  }
+
+  if (uses_predecessor && this->command_.type != CommandType::STATE_POLL) {
+    // The first non-poll predecessor attempt always consumes the capability,
+    // even when its command or replay status makes the frame inadmissible.
+    const bool accept_late_unlock =
+        is_fast_unlock_action && context.late_action_allowed;
+    context.late_action_allowed = false;
+    if (!accept_late_unlock) {
+      ESP_LOGW(TAG, "Dropping non-poll frame under superseded IV");
+      this->command_ = DecodedCommand{};
+      if (uses_retired) {
+        this->retired_ = CryptoContext{};
+      }
+      return Action::NONE;
+    }
   }
 
   if (this->command_.type == CommandType::UNKNOWN) {
@@ -144,9 +210,16 @@ LockSession::Action LockSession::process_frame(const std::string &frame) {
   if (this->command_.type == CommandType::LOCK || this->command_.type == CommandType::UNLOCK) {
     if (ciphertext_seen) {
       ESP_LOGW(TAG, "Dropping action: ciphertext replay within session");
+      if (uses_retired) {
+        this->retired_ = CryptoContext{};
+      }
       return Action::NONE;
     }
     this->record_ciphertext_(context, ciphertext, ct_len);
+    if (uses_predecessor) {
+      context.late_action_allowed = false;
+      ESP_LOGI(TAG, "Accepted one late action under predecessor IV");
+    }
   }
 
   std::memcpy(this->plaintext_.data(), plaintext, ct_len);
@@ -155,11 +228,23 @@ LockSession::Action LockSession::process_frame(const std::string &frame) {
   this->response_iv_valid_ = true;
 
   if (uses_pending) {
+    // Only a poll can race an older credential action. A state-changing or
+    // unknown frame under pending_ commits the new generation outright.
+    const bool retain_predecessor =
+        this->command_.type == CommandType::STATE_POLL && this->active_.valid &&
+        this->active_.late_action_allowed;
+    this->retired_ = retain_predecessor ? this->active_ : CryptoContext{};
     this->active_ = this->pending_;
+    this->active_.late_action_allowed = false;
+    this->active_.handoff_poll_seen = false;
     this->pending_ = CryptoContext{};
     ESP_LOGV(TAG, "Pending IV promoted");
+  } else if (uses_retired) {
+    // response_iv_ already snapshots the matching IV, so the one-frame
+    // predecessor can be destroyed before the bridge sends its ACK.
+    this->retired_ = CryptoContext{};
   } else if (this->pending_.valid) {
-    ESP_LOGD(TAG, "Accepted delayed state poll under previous IV");
+    ESP_LOGD(TAG, "Accepted delayed frame under active predecessor IV");
   }
 
   return Action::COMMAND;
@@ -169,6 +254,9 @@ bool LockSession::is_iv_request_(const std::string &frame) const {
   return frame.size() >= SESSION_IV_REQ_MIN &&
          static_cast<uint8_t>(frame[0]) == PROTOCOL_MAGIC &&
          static_cast<uint8_t>(frame[1]) == 0x00 &&
+         static_cast<uint8_t>(frame[2]) == 0x00 &&
+         static_cast<uint8_t>(frame[3]) == 0x00 &&
+         static_cast<uint8_t>(frame[4]) == 0x0F &&
          static_cast<uint8_t>(frame[5]) == 0x21 &&
          static_cast<uint8_t>(frame[6]) == 0x03;
 }
@@ -200,7 +288,32 @@ bool LockSession::xcrypt_(const std::array<uint8_t, AES_IV_SIZE> &iv,
   return aes_ctr_xcrypt(this->aes_key_, iv.data(), input, output, length);
 }
 
-void LockSession::rotate_pending_iv_() {
+void LockSession::ensure_pending_iv_() {
+  // The request carries no transaction identifier. Until a frame proves that
+  // the keypad adopted pending_, same-slot requests are retries of the same
+  // negotiation and must receive the same IV. Replacing it here strands a
+  // command already encrypted with the previously advertised IV (#19).
+  if (this->pending_.valid) {
+    std::memcpy(this->iv_response_.data() + IV_RESPONSE_HEADER,
+                this->pending_.iv.data(), AES_IV_SIZE);
+    ESP_LOGV(TAG, "Reusing pending IV: %s",
+             format_hex_pretty(this->pending_.iv.data(), AES_IV_SIZE).c_str());
+    return;
+  }
+
+  // A fresh request starts the next hand-off. The previously retired context
+  // is now more than one generation old and must not overlap the new pending
+  // IV. Arm a one-shot late-action allowance on the current active context;
+  // retries above deliberately neither replace pending_ nor alter this state.
+  this->retired_ = CryptoContext{};
+  if (this->active_.valid && this->slot_id_ == VISION_KEY_SLOT) {
+    this->active_.late_action_allowed = true;
+    this->active_.handoff_poll_seen = false;
+  } else if (this->active_.valid) {
+    this->active_.late_action_allowed = false;
+    this->active_.handoff_poll_seen = false;
+  }
+
   this->pending_ = CryptoContext{};
   auto fill_iv = [this]() {
     for (size_t i = 0; i < AES_IV_SIZE; i += 4) {

--- a/components/switchbot_keypad_bridge/lock_session.h
+++ b/components/switchbot_keypad_bridge/lock_session.h
@@ -49,9 +49,9 @@ class LockSession {
   // session and must keep the IV alive.
   void reset();
 
-  // Clear transient decoded-frame state while preserving the negotiated IV and
-  // replay window. Called on BLE connect/disconnect events because some
-  // keypads continue the same logical session after a transport reconnect.
+  // Clear transient decoded-frame state while preserving active/pending IVs
+  // and their replay windows. A transport boundary does revoke the one-shot
+  // Fast Unlock overlap, which is valid only within one BLE connection.
   void reset_transport();
 
   // Forget the learned token slot as well (pairing reset only).
@@ -84,7 +84,8 @@ class LockSession {
   static constexpr size_t REPLAY_HISTORY_SIZE = 8;
 
   bool is_iv_request_(const std::string &frame) const;
-  void rotate_pending_iv_();
+  void ensure_pending_iv_();
+  void clear_transient_();
 
   // AES-CTR is symmetric, so a single primitive covers both directions.
   bool xcrypt_(const std::array<uint8_t, AES_IV_SIZE> &iv, const uint8_t *input,
@@ -112,6 +113,8 @@ class LockSession {
     std::array<uint8_t, AES_IV_SIZE> iv{};
     std::array<ReplayEntry, REPLAY_HISTORY_SIZE> replay_history{};
     size_t replay_head{0};
+    bool late_action_allowed{false};
+    bool handoff_poll_seen{false};
     bool valid{false};
   };
 
@@ -123,6 +126,11 @@ class LockSession {
 
   CryptoContext active_{};
   CryptoContext pending_{};
+  // Immediate predecessor retained only when pending_ was committed by a
+  // state poll. The next valid encrypted frame, a fresh IV request, transport
+  // boundary, slot change or reset discards it. pending_ and retired_ never
+  // coexist.
+  CryptoContext retired_{};
 
   std::array<uint8_t, 20> iv_response_{0x01, 0x00, 0x00, 0x00};
 

--- a/tests/lock_session_test.cpp
+++ b/tests/lock_session_test.cpp
@@ -13,13 +13,22 @@ namespace {
 
 using esphome::switchbot_keypad_bridge::CommandType;
 using esphome::switchbot_keypad_bridge::LockSession;
+using esphome::switchbot_keypad_bridge::UnlockMethod;
 
 constexpr psa_key_id_t TEST_KEY = 0x42;
-constexpr uint8_t SLOT = 0xC6;
+constexpr uint8_t SLOT_VISION = 0xC6;
+constexpr uint8_t SLOT_TOUCH = 0x88;
 constexpr std::array<uint8_t, 4> STATE_POLL = {0x0F, 0x4F, 0x81, 0x00};
 constexpr std::array<uint8_t, 8> LOCK = {0x0F, 0x4E, 0x01, 0x03,
                                          0x00, 0x00, 0x00, 0x00};
+constexpr std::array<uint8_t, 8> UNLOCK = {0x0F, 0x4E, 0x01, 0x03,
+                                           0x04, 0x80, 0x00, 0x00};
+constexpr std::array<uint8_t, 8> FINGERPRINT_UNLOCK = {
+    0x0F, 0x4E, 0x01, 0x03, 0x0C, 0x80, 0x00, 0x00};
+constexpr std::array<uint8_t, 8> UNKNOWN_METHOD_UNLOCK = {
+    0x0F, 0x4E, 0x01, 0x03, 0x7C, 0x80, 0x00, 0x00};
 constexpr std::array<uint8_t, 2> DOORBELL = {0x01, 0x03};
+constexpr std::array<uint8_t, 4> UNKNOWN = {0xAA, 0xBB, 0xCC, 0xDD};
 
 std::deque<uint32_t> random_values;
 
@@ -39,8 +48,8 @@ void queue_iv(const std::array<uint8_t, 16> &iv) {
   }
 }
 
-std::string iv_request() {
-  const uint8_t bytes[8] = {0x57, 0x00, 0x00, 0x00, 0x0F, 0x21, 0x03, SLOT};
+std::string iv_request(uint8_t slot = SLOT_VISION) {
+  const uint8_t bytes[8] = {0x57, 0x00, 0x00, 0x00, 0x0F, 0x21, 0x03, slot};
   return {reinterpret_cast<const char *>(bytes), sizeof(bytes)};
 }
 
@@ -52,10 +61,11 @@ std::array<uint8_t, 16> response_iv(const LockSession &session) {
 
 template<size_t N>
 std::string encrypted_frame(const std::array<uint8_t, 16> &iv,
-                            const std::array<uint8_t, N> &plaintext) {
+                            const std::array<uint8_t, N> &plaintext,
+                            uint8_t slot = SLOT_VISION) {
   std::vector<uint8_t> wire(LockSession::HEADER_LEN + plaintext.size());
   wire[0] = 0x57;
-  wire[1] = SLOT;
+  wire[1] = slot;
   wire[2] = iv[0];
   wire[3] = iv[1];
   const bool ok = esphome::switchbot_keypad_bridge::aes_ctr_xcrypt(
@@ -81,6 +91,33 @@ void assert_response_uses_iv(LockSession &session,
   assert(std::memcmp(decoded, plaintext, sizeof(plaintext)) == 0);
 }
 
+template<size_t N>
+void assert_rejected_retired_attempt_closes_handoff(
+    const std::array<uint8_t, N> &payload, uint8_t seed) {
+  LockSession session;
+  session.set_aes_key(TEST_KEY);
+
+  const auto predecessor_iv = make_iv(seed);
+  const auto current_iv = make_iv(static_cast<uint8_t>(seed + 0x20));
+  queue_iv(predecessor_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(predecessor_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  queue_iv(current_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(current_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  assert(session.process_frame(encrypted_frame(predecessor_iv, payload)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(
+             encrypted_frame(predecessor_iv, FINGERPRINT_UNLOCK)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(current_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+}
+
 void test_iv_handoff_and_replay() {
   LockSession session;
   session.set_aes_key(TEST_KEY);
@@ -99,16 +136,20 @@ void test_iv_handoff_and_replay() {
   session.reset_transport();
   assert(session.process_frame(active_poll) == LockSession::Action::COMMAND);
 
-  const auto abandoned_pending_iv = make_iv(0x30);
-  queue_iv(abandoned_pending_iv);
-  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
-  assert(response_iv(session) == abandoned_pending_iv);
-
-  // A second IV request replaces only pending_, never the still-active IV.
-  const auto pending_iv = make_iv(0x50);
+  const auto pending_iv = make_iv(0x30);
   queue_iv(pending_iv);
   assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
   assert(response_iv(session) == pending_iv);
+
+  // Queue the next generation as a sentinel. Same-slot retries must not
+  // consume it or replace the uncommitted pending IV, even across reconnects.
+  const auto next_iv = make_iv(0x50);
+  queue_iv(next_iv);
+  session.reset_transport();
+  for (size_t i = 0; i < 3; ++i) {
+    assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+    assert(response_iv(session) == pending_iv);
+  }
 
   // The reported Vision Pro race: finish an old state poll after advertising
   // the next IV, and encrypt the reply with the old generation.
@@ -116,13 +157,11 @@ void test_iv_handoff_and_replay() {
   assert(session.command().type == CommandType::STATE_POLL);
   assert_response_uses_iv(session, active_iv);
 
-  // Only state polls may cross the hand-off boundary. Side effects remain
-  // rejected even if their ciphertext has not appeared in the replay ring.
-  assert(session.process_frame(encrypted_frame(active_iv, LOCK)) ==
-         LockSession::Action::NONE);
-
-  // A frame for an abandoned pending generation is neither active nor pending.
-  assert(session.process_frame(encrypted_frame(abandoned_pending_iv, STATE_POLL)) ==
+  // A reconnect preserves the negotiated contexts for #19, but deliberately
+  // revokes the one-connection Fast Unlock overlap.
+  const std::string active_lock = encrypted_frame(active_iv, LOCK);
+  assert(session.process_frame(active_lock) == LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(active_iv, FINGERPRINT_UNLOCK)) ==
          LockSession::Action::NONE);
 
   // The first frame under pending_ promotes it. Its replay entry moves with
@@ -141,9 +180,446 @@ void test_iv_handoff_and_replay() {
   assert(session.command().type == CommandType::DOORBELL);
   assert(session.process_frame(doorbell) == LockSession::Action::COMMAND);
 
+  // Once pending_ has been proven and promoted, the next request starts a
+  // genuinely new generation and consumes the queued RNG sentinel.
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(response_iv(session) == next_iv);
+
+  // The previous active generation remains available for a delayed poll and
+  // one Fast Unlock action while the new IV is still pending.
+  const std::string pending_poll = encrypted_frame(pending_iv, STATE_POLL);
+  assert(session.process_frame(pending_poll) == LockSession::Action::COMMAND);
+  assert_response_uses_iv(session, pending_iv);
+  const std::string pending_unlock = encrypted_frame(pending_iv, UNLOCK);
+  assert(session.process_frame(pending_unlock) == LockSession::Action::COMMAND);
+  assert(session.command().type == CommandType::UNLOCK);
+  assert_response_uses_iv(session, pending_iv);
+  assert(session.process_frame(pending_unlock) == LockSession::Action::NONE);
+
+  // Retrying the same IV negotiation is idempotent and cannot re-arm the
+  // predecessor capability after its one permitted action was consumed.
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(response_iv(session) == next_iv);
+  assert(session.process_frame(
+             encrypted_frame(pending_iv, FINGERPRINT_UNLOCK)) ==
+         LockSession::Action::NONE);
+
+  // A frame under next_iv commits the new generation and retires pending_iv.
+  assert(session.process_frame(encrypted_frame(next_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+  assert(session.process_frame(pending_poll) == LockSession::Action::NONE);
+
   // A full crypto reset (unpair/re-key) rejects the formerly active IV.
   session.reset();
+  assert(session.process_frame(encrypted_frame(next_iv, STATE_POLL)) ==
+         LockSession::Action::NONE);
+}
+
+void test_fast_unlock_after_pending_promotion() {
+  LockSession session;
+  session.set_aes_key(TEST_KEY);
+
+  const auto active_iv = make_iv(0x21);
+  queue_iv(active_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(active_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  // Fast Unlock ordering #2: the periodic poll commits pending_ before an
+  // unlock already encrypted with the predecessor reaches the bridge.
+  const auto next_iv = make_iv(0x41);
+  queue_iv(next_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(next_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+  assert_response_uses_iv(session, next_iv);
+
+  const std::string late_unlock =
+      encrypted_frame(active_iv, FINGERPRINT_UNLOCK);
+  assert(session.process_frame(late_unlock) == LockSession::Action::COMMAND);
+  assert(session.command().type == CommandType::UNLOCK);
+  assert(session.command().method == UnlockMethod::FINGERPRINT);
+  assert_response_uses_iv(session, active_iv);
+
+  // Consuming the one-shot predecessor removes it permanently.
+  assert(session.process_frame(late_unlock) == LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(active_iv, LOCK)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(next_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+}
+
+void test_fast_unlock_before_pending_promotion() {
+  {
+    LockSession session;
+    session.set_aes_key(TEST_KEY);
+    const auto predecessor_iv = make_iv(0x2E);
+    const auto pending_iv = make_iv(0x4E);
+    queue_iv(predecessor_iv);
+    assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+    assert(session.process_frame(encrypted_frame(predecessor_iv, STATE_POLL)) ==
+           LockSession::Action::COMMAND);
+    queue_iv(pending_iv);
+    assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+
+    // Ordering #1 from #22: the credential action arrives immediately after
+    // the new IV advertisement and before any poll commits it.
+    assert(session.process_frame(
+               encrypted_frame(predecessor_iv, FINGERPRINT_UNLOCK)) ==
+           LockSession::Action::COMMAND);
+    assert_response_uses_iv(session, predecessor_iv);
+    assert(session.process_frame(encrypted_frame(pending_iv, STATE_POLL)) ==
+           LockSession::Action::COMMAND);
+  }
+
+  {
+    LockSession session;
+    session.set_aes_key(TEST_KEY);
+    const auto predecessor_iv = make_iv(0x2F);
+    const auto pending_iv = make_iv(0x4F);
+    queue_iv(predecessor_iv);
+    assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+    assert(session.process_frame(encrypted_frame(predecessor_iv, STATE_POLL)) ==
+           LockSession::Action::COMMAND);
+    queue_iv(pending_iv);
+    assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+
+    // Plaintext IV retries neither advance nor close the event-bound handoff.
+    for (size_t i = 0; i < 3; ++i) {
+      assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+      assert(response_iv(session) == pending_iv);
+    }
+    assert(session.process_frame(encrypted_frame(predecessor_iv, UNLOCK)) ==
+           LockSession::Action::COMMAND);
+    assert_response_uses_iv(session, predecessor_iv);
+    assert(session.process_frame(encrypted_frame(pending_iv, STATE_POLL)) ==
+           LockSession::Action::COMMAND);
+  }
+}
+
+void test_predecessor_replay_consumes_handoff() {
+  LockSession session;
+  session.set_aes_key(TEST_KEY);
+
+  const auto predecessor_iv = make_iv(0x31);
+  const auto pending_iv = make_iv(0x51);
+  queue_iv(predecessor_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(predecessor_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  const std::string accepted_unlock = encrypted_frame(predecessor_iv, UNLOCK);
+  assert(session.process_frame(accepted_unlock) == LockSession::Action::COMMAND);
+
+  queue_iv(pending_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(accepted_unlock) == LockSession::Action::NONE);
+
+  // The rejected replay was still the first predecessor non-poll attempt and
+  // consumes the capability; a different old unlock cannot follow it.
+  assert(session.process_frame(
+             encrypted_frame(predecessor_iv, FINGERPRINT_UNLOCK)) ==
+         LockSession::Action::NONE);
   assert(session.process_frame(encrypted_frame(pending_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+}
+
+void test_rejected_predecessor_attempts_close_handoff() {
+  // The first predecessor non-poll frame consumes the one-shot regardless of
+  // whether it is admissible. This prevents unlimited probing without time.
+  assert_rejected_retired_attempt_closes_handoff(LOCK, 0x26);
+  assert_rejected_retired_attempt_closes_handoff(UNKNOWN, 0x27);
+  assert_rejected_retired_attempt_closes_handoff(DOORBELL, 0x28);
+  assert_rejected_retired_attempt_closes_handoff(UNKNOWN_METHOD_UNLOCK, 0x29);
+}
+
+void test_rejected_active_predecessor_attempt_closes_handoff() {
+  LockSession session;
+  session.set_aes_key(TEST_KEY);
+
+  const auto predecessor_iv = make_iv(0x2D);
+  const auto current_iv = make_iv(0x4D);
+  queue_iv(predecessor_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(predecessor_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  queue_iv(current_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(predecessor_iv, LOCK)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(
+             encrypted_frame(predecessor_iv, FINGERPRINT_UNLOCK)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(current_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+}
+
+void test_poll_budget_closes_state_only_handoff() {
+  LockSession session;
+  session.set_aes_key(TEST_KEY);
+
+  const auto predecessor_iv = make_iv(0x2A);
+  const auto current_iv = make_iv(0x4A);
+  queue_iv(predecessor_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  const std::string predecessor_poll =
+      encrypted_frame(predecessor_iv, STATE_POLL);
+  assert(session.process_frame(predecessor_poll) == LockSession::Action::COMMAND);
+
+  queue_iv(current_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+
+  // One in-flight predecessor poll is tolerated. A second closes the action
+  // allowance, while the new generation can still commit normally.
+  assert(session.process_frame(predecessor_poll) == LockSession::Action::COMMAND);
+  assert(session.process_frame(predecessor_poll) == LockSession::Action::COMMAND);
+  assert(session.process_frame(
+             encrypted_frame(predecessor_iv, FINGERPRINT_UNLOCK)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(current_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+}
+
+void test_next_encrypted_frame_closes_retired_handoff() {
+  {
+    LockSession session;
+    session.set_aes_key(TEST_KEY);
+    const auto predecessor_iv = make_iv(0x2B);
+    const auto current_iv = make_iv(0x4B);
+    queue_iv(predecessor_iv);
+    assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+    assert(session.process_frame(encrypted_frame(predecessor_iv, STATE_POLL)) ==
+           LockSession::Action::COMMAND);
+    queue_iv(current_iv);
+    assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+    assert(session.process_frame(encrypted_frame(current_iv, STATE_POLL)) ==
+           LockSession::Action::COMMAND);
+
+    // A current-generation poll is the next valid encrypted frame, so the
+    // predecessor action can no longer follow it.
+    assert(session.process_frame(encrypted_frame(current_iv, STATE_POLL)) ==
+           LockSession::Action::COMMAND);
+    assert(session.process_frame(
+               encrypted_frame(predecessor_iv, FINGERPRINT_UNLOCK)) ==
+           LockSession::Action::NONE);
+  }
+
+  {
+    LockSession session;
+    session.set_aes_key(TEST_KEY);
+    const auto predecessor_iv = make_iv(0x2C);
+    const auto current_iv = make_iv(0x4C);
+    queue_iv(predecessor_iv);
+    assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+    assert(session.process_frame(encrypted_frame(predecessor_iv, STATE_POLL)) ==
+           LockSession::Action::COMMAND);
+    queue_iv(current_iv);
+    assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+    assert(session.process_frame(encrypted_frame(current_iv, STATE_POLL)) ==
+           LockSession::Action::COMMAND);
+
+    // A delayed predecessor poll may be answered, but it consumes the same
+    // next-frame hand-off opportunity.
+    assert(session.process_frame(encrypted_frame(predecessor_iv, STATE_POLL)) ==
+           LockSession::Action::COMMAND);
+    assert_response_uses_iv(session, predecessor_iv);
+    assert(session.process_frame(
+               encrypted_frame(predecessor_iv, FINGERPRINT_UNLOCK)) ==
+           LockSession::Action::NONE);
+  }
+}
+
+void test_current_generation_action_closes_retired_handoff() {
+  LockSession session;
+  session.set_aes_key(TEST_KEY);
+
+  const auto old_iv = make_iv(0x24);
+  const auto active_iv = make_iv(0x44);
+  queue_iv(old_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(old_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  queue_iv(active_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(active_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  // Once a newer side effect has been accepted, an older unlock must never
+  // run afterwards and invert that state transition.
+  assert(session.process_frame(encrypted_frame(active_iv, LOCK)) ==
+         LockSession::Action::COMMAND);
+  assert(session.command().type == CommandType::LOCK);
+  assert(session.process_frame(encrypted_frame(old_iv, FINGERPRINT_UNLOCK)) ==
+         LockSession::Action::NONE);
+}
+
+void test_transport_reset_revokes_fast_unlock_handoff() {
+  LockSession session;
+  session.set_aes_key(TEST_KEY);
+
+  const auto iv_a = make_iv(0x25);
+  const auto iv_b = make_iv(0x45);
+  const auto iv_c = make_iv(0x65);
+  queue_iv(iv_a);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(iv_a, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  // active+pending survive reconnect for protocol continuity, but the late
+  // action allowance belongs to the old BLE transport and is revoked.
+  queue_iv(iv_b);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  session.reset_transport();
+  assert(session.process_frame(encrypted_frame(iv_a, FINGERPRINT_UNLOCK)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(iv_b, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  // Exercise the same boundary after a poll created retired_.
+  queue_iv(iv_c);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(iv_c, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+  session.reset_transport();
+  assert(session.process_frame(encrypted_frame(iv_b, FINGERPRINT_UNLOCK)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(iv_c, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+}
+
+void test_continuous_fast_unlock_rotations_keep_one_predecessor() {
+  LockSession session;
+  session.set_aes_key(TEST_KEY);
+
+  const auto iv_a = make_iv(0x12);
+  const auto iv_b = make_iv(0x32);
+  const auto iv_c = make_iv(0x52);
+
+  queue_iv(iv_a);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(iv_a, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  queue_iv(iv_b);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(iv_b, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  queue_iv(iv_c);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(iv_c, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  // After A -> B -> C, only B is the immediate predecessor. This reproduces
+  // the seq-mismatch variant of #22 without admitting arbitrarily old IVs.
+  assert(session.process_frame(encrypted_frame(iv_a, FINGERPRINT_UNLOCK)) ==
+         LockSession::Action::NONE);
+  const std::string late_b = encrypted_frame(iv_b, FINGERPRINT_UNLOCK);
+  assert(session.process_frame(late_b) == LockSession::Action::COMMAND);
+  assert(session.command().type == CommandType::UNLOCK);
+  assert_response_uses_iv(session, iv_b);
+  assert(session.process_frame(late_b) == LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(iv_c, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+}
+
+void test_slot_change_invalidates_crypto_generations() {
+  LockSession session;
+  session.set_aes_key(TEST_KEY);
+
+  const auto vision_active_iv = make_iv(0x80);
+  queue_iv(vision_active_iv);
+  assert(session.process_frame(iv_request(SLOT_VISION)) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(vision_active_iv, STATE_POLL, SLOT_VISION)) ==
+         LockSession::Action::COMMAND);
+
+  const auto vision_pending_iv = make_iv(0xA0);
+  queue_iv(vision_pending_iv);
+  assert(session.process_frame(iv_request(SLOT_VISION)) == LockSession::Action::SEND_IV);
+  assert(response_iv(session) == vision_pending_iv);
+
+  // A slot change is a hard crypto boundary, not a retry of the Vision
+  // transaction. It must discard both old contexts and advertise a fresh IV.
+  const auto touch_iv = make_iv(0xC0);
+  queue_iv(touch_iv);
+  assert(session.process_frame(iv_request(SLOT_TOUCH)) == LockSession::Action::SEND_IV);
+  assert(response_iv(session) == touch_iv);
+
+  // Relabelling either old context with the new, unauthenticated key_id must
+  // not make it admissible under the Touch slot.
+  assert(session.process_frame(encrypted_frame(vision_active_iv, STATE_POLL, SLOT_TOUCH)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(vision_pending_iv, STATE_POLL, SLOT_TOUCH)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(touch_iv, STATE_POLL, SLOT_TOUCH)) ==
+         LockSession::Action::COMMAND);
+
+  // Touch deliberately gets no predecessor allowance. Its previous generation is
+  // dropped when the next poll commits, while the new generation stays active.
+  const auto touch_next_iv = make_iv(0xD0);
+  queue_iv(touch_next_iv);
+  assert(session.process_frame(iv_request(SLOT_TOUCH)) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(
+             encrypted_frame(touch_iv, FINGERPRINT_UNLOCK, SLOT_TOUCH)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(touch_next_iv, STATE_POLL, SLOT_TOUCH)) ==
+         LockSession::Action::COMMAND);
+
+  // Switching back is another hard boundary; neither Touch generation can be
+  // relabelled for Vision.
+  const auto new_vision_iv = make_iv(0xE0);
+  queue_iv(new_vision_iv);
+  assert(session.process_frame(iv_request(SLOT_VISION)) == LockSession::Action::SEND_IV);
+  assert(response_iv(session) == new_vision_iv);
+  assert(session.process_frame(encrypted_frame(touch_iv, STATE_POLL, SLOT_VISION)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(touch_next_iv, STATE_POLL, SLOT_VISION)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(new_vision_iv, STATE_POLL, SLOT_VISION)) ==
+         LockSession::Action::COMMAND);
+
+  // Create a real Vision retired+active pair, then switch slots once more.
+  // Both generations must be discarded at that hard crypto boundary.
+  const auto vision_next_iv = make_iv(0x18);
+  queue_iv(vision_next_iv);
+  assert(session.process_frame(iv_request(SLOT_VISION)) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(vision_next_iv, STATE_POLL, SLOT_VISION)) ==
+         LockSession::Action::COMMAND);
+
+  const auto final_touch_iv = make_iv(0x38);
+  queue_iv(final_touch_iv);
+  assert(session.process_frame(iv_request(SLOT_TOUCH)) == LockSession::Action::SEND_IV);
+  assert(response_iv(session) == final_touch_iv);
+  assert(session.process_frame(encrypted_frame(new_vision_iv, STATE_POLL, SLOT_TOUCH)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(vision_next_iv, STATE_POLL, SLOT_TOUCH)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(final_touch_iv, STATE_POLL, SLOT_TOUCH)) ==
+         LockSession::Action::COMMAND);
+}
+
+void test_full_reset_clears_retired_generation() {
+  LockSession session;
+  session.set_aes_key(TEST_KEY);
+
+  const auto old_iv = make_iv(0xA4);
+  const auto active_iv = make_iv(0xC4);
+  queue_iv(old_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(old_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  queue_iv(active_iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(session.process_frame(encrypted_frame(active_iv, STATE_POLL)) ==
+         LockSession::Action::COMMAND);
+
+  session.reset();
+  assert(session.process_frame(encrypted_frame(old_iv, FINGERPRINT_UNLOCK)) ==
+         LockSession::Action::NONE);
+  assert(session.process_frame(encrypted_frame(active_iv, STATE_POLL)) ==
          LockSession::Action::NONE);
 }
 
@@ -164,6 +640,23 @@ void test_seq_collision_is_resolved() {
   assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
   const auto pending_iv = response_iv(session);
   assert(pending_iv[0] != active_iv[0] || pending_iv[1] != active_iv[1]);
+}
+
+void test_iv_request_requires_complete_fixed_header() {
+  LockSession session;
+  session.set_aes_key(TEST_KEY);
+
+  for (const size_t index : {size_t{2}, size_t{3}, size_t{4}}) {
+    std::string malformed = iv_request();
+    malformed[index] = static_cast<char>(
+        static_cast<uint8_t>(malformed[index]) ^ 0x01);
+    assert(session.process_frame(malformed) == LockSession::Action::NONE);
+  }
+
+  const auto iv = make_iv(0x76);
+  queue_iv(iv);
+  assert(session.process_frame(iv_request()) == LockSession::Action::SEND_IV);
+  assert(response_iv(session) == iv);
 }
 
 }  // namespace
@@ -191,7 +684,20 @@ bool aes_ctr_xcrypt(psa_key_id_t key, const uint8_t iv[16],
 
 int main() {
   test_iv_handoff_and_replay();
+  test_fast_unlock_before_pending_promotion();
+  test_fast_unlock_after_pending_promotion();
+  test_predecessor_replay_consumes_handoff();
+  test_rejected_predecessor_attempts_close_handoff();
+  test_rejected_active_predecessor_attempt_closes_handoff();
+  test_poll_budget_closes_state_only_handoff();
+  test_next_encrypted_frame_closes_retired_handoff();
+  test_current_generation_action_closes_retired_handoff();
+  test_transport_reset_revokes_fast_unlock_handoff();
+  test_continuous_fast_unlock_rotations_keep_one_predecessor();
+  test_slot_change_invalidates_crypto_generations();
+  test_full_reset_clears_retired_generation();
   test_seq_collision_is_resolved();
+  test_iv_request_requires_complete_fixed_header();
   assert(random_values.empty());
   return 0;
 }


### PR DESCRIPTION
## Summary

- keep the immediate predecessor IV during Keypad Vision Fast Unlock handoffs so an in-flight credential unlock can be accepted and acknowledged with the matching IV
- make repeated IV requests idempotent, validate the complete request header, and treat token-slot changes as hard crypto boundaries
- bound predecessor acceptance to one known unlock method while preserving replay protection and revoking the allowance on reconnect, newer traffic, or a completed handoff
- expand LockSession coverage for both Fast Unlock orderings, replays, retries, transport resets, continuous rotations, slot changes, and malformed requests

## Testing

- LockSession suite compiled and passed with MSVC (`/std:c++17 /W4 /WX`)
- LockSession suite compiled and passed with Clang (`-std=c++17 -Wall -Wextra -Werror`)
- validated on device with Fast Unlock enabled

## Issue scope

Closes #22.

This also preserves regression coverage for the IV-retry behavior discussed in #19.

#14 is intentionally not closed: face auto-scan re-arming depends on reporting a locked/door-closed state, which this crypto-session fix does not implement.