### PR TITLE
feat: expose locked-state sync button

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ switchbot_keypad_bridge:
 | `lock_battery_level` | sensor | no | Battery percentage of the linked physical lock, read from its BLE advertisement (Diagnostic category). |
 | `battery_scan_interval` | time | no | How often the bridge refreshes keypad and lock battery sensors with the shared advertisement scan. Default `15min`. |
 | `reset_button` | button | no | Button that forgets the linked keypad and lock, rotates the session key and re-opens the setup wizard (no reboot). |
-| `lock_button` | button | no | Reports the emulated lock as locked on the keypad's next state poll. Use it to synchronize an external lock and re-arm Keypad Vision face recognition. |
+| `report_locked_button` | button | no | Reports the emulated lock as locked on the keypad's next state poll. It does not operate a physical lock. Use it to synchronize an external lock and re-arm Keypad Vision face recognition. |
 | `on_lock` | automation | no | Triggered on every `lock` command. |
 | `on_unlock` | automation | no | Triggered on every `unlock` command — parameters `(std::string method, int index)`. |
 | `on_doorbell` | automation | no | Triggered on every doorbell press (Keypad Vision). No parameters. |
@@ -269,13 +269,13 @@ switchbot_keypad_bridge:
 
 Keypad Vision stops passive face recognition after a successful unlock until
 the paired lock reports that it is locked again. When Home Assistant controls a
-different physical lock, expose `lock_button` and press it whenever that lock
-reaches its locked state:
+different physical lock, expose `report_locked_button` and press it whenever
+that lock reaches its locked state:
 
 ```yaml
 switchbot_keypad_bridge:
-  lock_button:
-    name: "Report locked"
+  report_locked_button:
+    name: "Sync locked state to keypad"
 ```
 
 ```yaml
@@ -287,7 +287,7 @@ triggers:
 actions:
   - action: button.press
     target:
-      entity_id: button.switchbot_keypad_bridge_report_locked
+      entity_id: button.switchbot_keypad_bridge_sync_locked_state_to_keypad
 mode: queued
 ```
 

--- a/README.md
+++ b/README.md
@@ -260,9 +260,39 @@ switchbot_keypad_bridge:
 | `lock_battery_level` | sensor | no | Battery percentage of the linked physical lock, read from its BLE advertisement (Diagnostic category). |
 | `battery_scan_interval` | time | no | How often the bridge refreshes keypad and lock battery sensors with the shared advertisement scan. Default `15min`. |
 | `reset_button` | button | no | Button that forgets the linked keypad and lock, rotates the session key and re-opens the setup wizard (no reboot). |
+| `lock_button` | button | no | Reports the emulated lock as locked on the keypad's next state poll. Use it to synchronize an external lock and re-arm Keypad Vision face recognition. |
 | `on_lock` | automation | no | Triggered on every `lock` command. |
 | `on_unlock` | automation | no | Triggered on every `unlock` command — parameters `(std::string method, int index)`. |
 | `on_doorbell` | automation | no | Triggered on every doorbell press (Keypad Vision). No parameters. |
+
+### Synchronizing an external lock
+
+Keypad Vision stops passive face recognition after a successful unlock until
+the paired lock reports that it is locked again. When Home Assistant controls a
+different physical lock, expose `lock_button` and press it whenever that lock
+reaches its locked state:
+
+```yaml
+switchbot_keypad_bridge:
+  lock_button:
+    name: "Report locked"
+```
+
+```yaml
+alias: Re-arm SwitchBot keypad when the door locks
+triggers:
+  - trigger: state
+    entity_id: lock.front_door
+    to: "locked"
+actions:
+  - action: button.press
+    target:
+      entity_id: button.switchbot_keypad_bridge_report_locked
+mode: queued
+```
+
+The button changes only the state reported to the keypad. It does not operate a
+linked physical lock.
 
 ## 🔬 Under the hood
 

--- a/components/switchbot_keypad_bridge/__init__.py
+++ b/components/switchbot_keypad_bridge/__init__.py
@@ -55,6 +55,7 @@ CONF_KEYPAD_BATTERY_LEVEL = "keypad_battery_level"
 CONF_LOCK_BATTERY_LEVEL = "lock_battery_level"
 CONF_BATTERY_SCAN_INTERVAL = "battery_scan_interval"
 CONF_RESET_BUTTON = "reset_button"
+CONF_LOCK_BUTTON = "lock_button"
 CONF_ON_LOCK = "on_lock"
 CONF_ON_UNLOCK = "on_unlock"
 CONF_ON_DOORBELL = "on_doorbell"
@@ -73,6 +74,7 @@ SwitchbotKeypadBridge = switchbot_keypad_bridge_ns.class_(
     "SwitchbotKeypadBridge", cg.Component
 )
 ResetButton = switchbot_keypad_bridge_ns.class_("ResetButton", button.Button)
+LockButton = switchbot_keypad_bridge_ns.class_("LockButton", button.Button)
 LockTrigger = switchbot_keypad_bridge_ns.class_(
     "LockTrigger", automation.Trigger.template()
 )
@@ -137,6 +139,11 @@ CONFIG_SCHEMA = cv.Schema(
             ResetButton,
             entity_category=ENTITY_CATEGORY_CONFIG,
             icon="mdi:restart",
+        ),
+        cv.Optional(CONF_LOCK_BUTTON): button.button_schema(
+            LockButton,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+            icon="mdi:lock",
         ),
         cv.GenerateID(CONF_PAIRING_UI_HTML_ID): cv.declare_id(cg.uint8),
         cv.Optional(CONF_ON_LOCK): automation.validate_automation(
@@ -231,6 +238,10 @@ async def to_code(config):
         )
 
     if button_conf := config.get(CONF_RESET_BUTTON):
+        btn = await button.new_button(button_conf)
+        await cg.register_parented(btn, config[CONF_ID])
+
+    if button_conf := config.get(CONF_LOCK_BUTTON):
         btn = await button.new_button(button_conf)
         await cg.register_parented(btn, config[CONF_ID])
 

--- a/components/switchbot_keypad_bridge/__init__.py
+++ b/components/switchbot_keypad_bridge/__init__.py
@@ -55,7 +55,7 @@ CONF_KEYPAD_BATTERY_LEVEL = "keypad_battery_level"
 CONF_LOCK_BATTERY_LEVEL = "lock_battery_level"
 CONF_BATTERY_SCAN_INTERVAL = "battery_scan_interval"
 CONF_RESET_BUTTON = "reset_button"
-CONF_LOCK_BUTTON = "lock_button"
+CONF_REPORT_LOCKED_BUTTON = "report_locked_button"
 CONF_ON_LOCK = "on_lock"
 CONF_ON_UNLOCK = "on_unlock"
 CONF_ON_DOORBELL = "on_doorbell"
@@ -74,7 +74,9 @@ SwitchbotKeypadBridge = switchbot_keypad_bridge_ns.class_(
     "SwitchbotKeypadBridge", cg.Component
 )
 ResetButton = switchbot_keypad_bridge_ns.class_("ResetButton", button.Button)
-LockButton = switchbot_keypad_bridge_ns.class_("LockButton", button.Button)
+ReportLockedButton = switchbot_keypad_bridge_ns.class_(
+    "ReportLockedButton", button.Button
+)
 LockTrigger = switchbot_keypad_bridge_ns.class_(
     "LockTrigger", automation.Trigger.template()
 )
@@ -140,10 +142,10 @@ CONFIG_SCHEMA = cv.Schema(
             entity_category=ENTITY_CATEGORY_CONFIG,
             icon="mdi:restart",
         ),
-        cv.Optional(CONF_LOCK_BUTTON): button.button_schema(
-            LockButton,
+        cv.Optional(CONF_REPORT_LOCKED_BUTTON): button.button_schema(
+            ReportLockedButton,
             entity_category=ENTITY_CATEGORY_CONFIG,
-            icon="mdi:lock",
+            icon="mdi:lock-check",
         ),
         cv.GenerateID(CONF_PAIRING_UI_HTML_ID): cv.declare_id(cg.uint8),
         cv.Optional(CONF_ON_LOCK): automation.validate_automation(
@@ -241,7 +243,7 @@ async def to_code(config):
         btn = await button.new_button(button_conf)
         await cg.register_parented(btn, config[CONF_ID])
 
-    if button_conf := config.get(CONF_LOCK_BUTTON):
+    if button_conf := config.get(CONF_REPORT_LOCKED_BUTTON):
         btn = await button.new_button(button_conf)
         await cg.register_parented(btn, config[CONF_ID])
 

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
@@ -418,6 +418,11 @@ void ResetButton::press_action() {
   this->parent_->reset_pairing();
 }
 
+void LockButton::press_action() {
+  ESP_LOGI(TAG, "Reporting emulated lock state as locked");
+  this->parent_->set_lock_state(true);
+}
+
 void SwitchbotKeypadBridge::dump_config() {
   ESP_LOGCONFIG(TAG, "SwitchBot Keypad Bridge:");
   ESP_LOGCONFIG(TAG, "  BLE address: %s", NimBLEDevice::getAddress().toString().c_str());

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.cpp
@@ -418,8 +418,8 @@ void ResetButton::press_action() {
   this->parent_->reset_pairing();
 }
 
-void LockButton::press_action() {
-  ESP_LOGI(TAG, "Reporting emulated lock state as locked");
+void ReportLockedButton::press_action() {
+  ESP_LOGI(TAG, "Reporting locked state to the keypad");
   this->parent_->set_lock_state(true);
 }
 

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
@@ -82,6 +82,14 @@ class SwitchbotKeypadBridge : public Component {
   // re-opens the setup wizard — no reboot. Invoked by ResetButton.
   void reset_pairing();
 
+  // Sets the state reported on the keypad's next state poll. This lets an
+  // external lock or door controller keep the emulated lock state in sync.
+  // ESPHome actions run on the main task, so mutating lock_state_ here follows
+  // the component's concurrency model.
+  void set_lock_state(bool locked) {
+    this->lock_state_ = locked ? LockState::LOCKED : LockState::UNLOCKED;
+  }
+
   void add_on_lock_callback(std::function<void()> &&callback) {
     this->on_lock_callbacks_.add(std::move(callback));
   }
@@ -312,6 +320,13 @@ class SwitchbotKeypadBridge : public Component {
 // Home Assistant reset button: forgets keypad and lock, rotates the shared key
 // and re-opens the setup wizard — all without a reboot.
 class ResetButton : public button::Button, public Parented<SwitchbotKeypadBridge> {
+ protected:
+  void press_action() override;
+};
+
+// Home Assistant button that reports the emulated lock as locked. Keypad
+// Vision uses this state to re-arm passive face recognition after an unlock.
+class LockButton : public button::Button, public Parented<SwitchbotKeypadBridge> {
  protected:
   void press_action() override;
 };

--- a/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
+++ b/components/switchbot_keypad_bridge/switchbot_keypad_bridge.h
@@ -324,9 +324,11 @@ class ResetButton : public button::Button, public Parented<SwitchbotKeypadBridge
   void press_action() override;
 };
 
-// Home Assistant button that reports the emulated lock as locked. Keypad
-// Vision uses this state to re-arm passive face recognition after an unlock.
-class LockButton : public button::Button, public Parented<SwitchbotKeypadBridge> {
+// Home Assistant button that reports the emulated lock as locked. It does not
+// operate a physical lock. Keypad Vision uses the reported state to re-arm
+// passive face recognition after an unlock.
+class ReportLockedButton : public button::Button,
+                           public Parented<SwitchbotKeypadBridge> {
  protected:
   void press_action() override;
 };

--- a/switchbot-keypad-bridge.yaml
+++ b/switchbot-keypad-bridge.yaml
@@ -55,10 +55,11 @@ switchbot_keypad_bridge:
   reset_button:
     name: "Reset"
 
-  # Report the emulated lock as locked from Home Assistant. This re-arms
-  # passive face recognition on Keypad Vision after an unlock.
-  lock_button:
-    name: "Report locked"
+  # Report the emulated lock as locked from Home Assistant. This does not
+  # operate a physical lock; it re-arms passive face recognition on Keypad
+  # Vision after an unlock.
+  report_locked_button:
+    name: "Sync locked state to keypad"
 
   on_unlock:
     # method: "pin" | "fingerprint" | "nfc" | "face" | "unknown"   index: credential slot

--- a/switchbot-keypad-bridge.yaml
+++ b/switchbot-keypad-bridge.yaml
@@ -55,6 +55,11 @@ switchbot_keypad_bridge:
   reset_button:
     name: "Reset"
 
+  # Report the emulated lock as locked from Home Assistant. This re-arms
+  # passive face recognition on Keypad Vision after an unlock.
+  lock_button:
+    name: "Report locked"
+
   on_unlock:
     # method: "pin" | "fingerprint" | "nfc" | "face" | "unknown"   index: credential slot
     - homeassistant.event:

--- a/tests/compile.wt32-eth01.yaml
+++ b/tests/compile.wt32-eth01.yaml
@@ -44,5 +44,5 @@ switchbot_keypad_bridge:
     name: Lock battery
   reset_button:
     name: Reset
-  lock_button:
-    name: Report locked
+  report_locked_button:
+    name: Sync locked state to keypad

--- a/tests/compile.wt32-eth01.yaml
+++ b/tests/compile.wt32-eth01.yaml
@@ -44,3 +44,5 @@ switchbot_keypad_bridge:
     name: Lock battery
   reset_button:
     name: Reset
+  lock_button:
+    name: Report locked


### PR DESCRIPTION
## Summary

- add an optional `report_locked_button` ESPHome entity that reports the emulated lock as locked on the keypad's next state poll
- expose `set_lock_state(bool)` for local ESPHome automations and external lock or door controllers
- document a Home Assistant state-trigger automation for re-arming Keypad Vision face recognition
- cover the new configuration in the ESPHome compile fixture and example YAML

The button only synchronizes state to the keypad; it does not operate a physical lock. This lets installations using a different lock re-arm passive face recognition after that lock reports a locked state.

Addresses #14.

## Verification

- `./tests/run_lock_session_tests.sh`
- `python3 -m py_compile components/switchbot_keypad_bridge/__init__.py`
- ESPHome 2026.8.2: `esphome compile tests/compile.wt32-eth01.yaml`
- `git diff --check`
